### PR TITLE
Debug symbols forced to DWARF 3 instead of GCC11 default DWARF 5.

### DIFF
--- a/build-toolchain-msys2
+++ b/build-toolchain-msys2
@@ -149,6 +149,8 @@ if [[ $* == *--gcc-stage1* || $* == *--all* ]]; then
 	CFLAGS='-I/mingw32/include' \
 	CXXFLAGS='-I/mingw32/include' \
 	LDFLAGS='-static -L/mingw32/lib' \
+	CFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
+	CXXFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
 	--target=tricore-elf \
 	--build=i686-w64-mingw32 \
 	--host=i686-w64-mingw32 \
@@ -157,7 +159,7 @@ if [[ $* == *--gcc-stage1* || $* == *--all* ]]; then
 	--disable-lib64 \
 	--prefix=$INSTALL_FOLDER \
 	--enable-languages=c,c++ \
-	--enable-libstdcxx-debug-flags='-gdwarf-3 -g3 -O0 -D_GLIBCXX_ASSERTIONS' \
+	--enable-libstdcxx-debug-flags='-gdwarf-3 -g -O0 -D_GLIBCXX_ASSERTIONS' \
 	--enable-c99 \
 	--enable-long-long \
 	--enable-checking \
@@ -212,8 +214,8 @@ if [[ $* == *--newlib* || $* == *--all* ]]; then
 	export RANLIB_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-ranlib
 	export STRIP_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-strip
 	export READELF_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-readelf
-	if ! CFLAGS_FOR_TARGET='-g -O2 -ffast-math -ffunction-sections -mfast-div -fno-common' \
-	CPPFLAGS_FOR_TARGET='-g -O2 -ffast-math -ffunction-sections -mfast-div -fno-common' \
+	if ! CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffast-math -ffunction-sections -mfast-div -fno-common' \
+	CXXFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffast-math -ffunction-sections -mfast-div -fno-common' \
 	$NEWLIB_SRC_FOLDER/configure \
 	--target=tricore-elf \
 	--host=x86_64-linux-gnu \
@@ -222,7 +224,7 @@ if [[ $* == *--newlib* || $* == *--all* ]]; then
 		echo "The build has failed during configure of newlib"
 		exit 1
 	fi
-	make -j${PARALLEL_JOBS} LDFLAGS="-static" all 2>&1 | tee $LOG_FOLDER/newlib.log
+	make -j${PARALLEL_JOBS} LDFLAGS="-static " all 2>&1 | tee $LOG_FOLDER/newlib.log
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during make of newlib"
 	fi
@@ -249,6 +251,8 @@ if [[ $* == *--gcc-stage2* || $* == *--all* ]]; then
 	CFLAGS='-I/mingw32/include' \
 	CXXFLAGS='-I/mingw32/include' \
 	LDFLAGS='-static -L/mingw32/lib' \
+	CFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
+	CXXFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
 	--target=tricore-elf \
 	--build=i686-w64-mingw32 \
 	--host=i686-w64-mingw32 \
@@ -257,7 +261,7 @@ if [[ $* == *--gcc-stage2* || $* == *--all* ]]; then
 	--disable-lib64 \
 	--prefix=$INSTALL_FOLDER \
 	--enable-languages=c,c++ \
-	--enable-libstdcxx-debug-flags='-gdwarf-3 -g3 -O0 -D_GLIBCXX_ASSERTIONS' \
+	--enable-libstdcxx-debug-flags='-gdwarf-3 -g -O0 -D_GLIBCXX_ASSERTIONS' \
 	--enable-c99 \
 	--enable-long-long \
 	--enable-checking \


### PR DESCRIPTION
Modification performed to guarantee compatibility of generated ELF files with Eclipse CDT.