### PR TITLE
Merge linux-crosscompile, improve build script, add CI build and release pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'feature/**'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Toolchain build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: sudo ./install-deps
+
+      - name: Build
+        run: ./build-toolchain
+
+      - name: Package
+        run: |
+          cd ./INSTALL
+          zip -r9 ../linux.zip .
+          cd ../INSTALL-WIN
+          zip -r9X ../win32.zip .
+      
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: error
+          name: tricore-gcc-artifacts
+          path: ./*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Publish Release artifacts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      
+      - name: Extract commit SHA
+        shell: bash
+        run: |
+          echo "SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
+
+      - name: Download artifacts from latest workflow
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: build.yml
+          branch: ${{ github.event.release.target_commitish }}
+          workflow_conclusion: success
+          skip_unpack: false
+
+      - name: Rename build artifacts
+        run: |
+          mv tricore-gcc-artifacts/linux.zip tricore-gcc-11.3.1-${{ env.SHORT_SHA }}-linux.zip
+          mv tricore-gcc-artifacts/win32.zip tricore-gcc-11.3.1-${{ env.SHORT_SHA }}-win32.zip
+
+      - name: Push release artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            *.zip

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ BUILD
 
 # Install folder
 INSTALL
+INSTALL-WIN
 
 # Log folder
 LOG

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ git clone --recursive git@github.com:EEESlab/tricore-gcc-toolchain-11.3.0.git
 Launch the build script:
 
 ```
-./build-toolchain --all
+./build-toolchain
 ```
 
 It is also possible to compile single components of the toolchain. For further information on the available options:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ Launch the build script:
 ./build-toolchain
 ```
 
-It is also possible to compile single components of the toolchain. For further information on the available options:
+It is also possible to compile single components of the toolchain.
+
+```
+./build-toolchain --build --only binutils-tc
+```
+
+For further information on the available options:
 
 ```
 ./build-toolchain --help

--- a/build-toolchain
+++ b/build-toolchain
@@ -48,7 +48,7 @@ parse_params() {
 		--clean-all) clean_all_artifacts ;;
 		-c | --clean) build_task="clean" ;;
 		-b | --build) build_task="build" ;;
-		-o | --only-step)
+		-o | --only)
 		build_step="${2-}"
 		shift
 		;;

--- a/build-toolchain
+++ b/build-toolchain
@@ -37,7 +37,6 @@ if [[ $* == "--binutils-mcs" || $* == *--all* ]]; then
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/binutils-mcs
 	if ! $BINUTILS_SRC_FOLDER/configure \
-	LDFLAGS='-static' \
 	--target=mcs-elf \
 	--program-prefix=mcs-elf- \
 	--disable-threads \
@@ -63,7 +62,7 @@ if [[ $* == "--binutils-mcs" || $* == *--all* ]]; then
 		echo "The build has failed during configure of binutils-mcs"
 		exit 1
 	fi
-        make --output-sync -j${PARALLEL_JOBS} LDFLAGS="-static" 2>&1 | tee $LOG_FOLDER/binutils_mcs.log
+        make --output-sync -j${PARALLEL_JOBS} 2>&1 | tee $LOG_FOLDER/binutils_mcs.log
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during make of binutils-mcs"
 		exit 1
@@ -88,7 +87,6 @@ if [[ $* == "--binutils" || $* == *--all* ]]; then
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/binutils
 	if ! $BINUTILS_SRC_FOLDER/configure \
-	LDFLAGS='-static' \
 	--target=tricore-elf \
 	--enable-targets=mcs-elf \
 	--program-prefix=tricore-elf- \
@@ -115,7 +113,7 @@ if [[ $* == "--binutils" || $* == *--all* ]]; then
 		echo "The build has failed during configure of binutils"
 		exit 1
 	fi
-	make --output-sync -j${PARALLEL_JOBS} LDFLAGS="-static" 2>&1 | tee $LOG_FOLDER/binutils.log
+	make --output-sync -j${PARALLEL_JOBS} 2>&1 | tee $LOG_FOLDER/binutils.log
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during make of binutils"
 		exit 1
@@ -140,7 +138,6 @@ if [[ $* == *--gcc-stage1* || $* == *--all* ]]; then
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/gcc-stage1
 	if ! $GCC_SRC_FOLDER/configure \
-	LDFLAGS='-static' \
 	CFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
 	CXXFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
 	--target=tricore-elf \
@@ -213,7 +210,7 @@ if [[ $* == *--newlib* || $* == *--all* ]]; then
 		echo "The build has failed during configure of newlib"
 		exit 1
 	fi
-	make -j${PARALLEL_JOBS} LDFLAGS="-static" all 2>&1 | tee $LOG_FOLDER/newlib.log
+	make -j${PARALLEL_JOBS} all 2>&1 | tee $LOG_FOLDER/newlib.log
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during make of newlib"
 	fi
@@ -237,7 +234,6 @@ if [[ $* == "--gcc-stage2" || $* == *--all* ]]; then
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/gcc-stage2
 	if ! $GCC_SRC_FOLDER/configure \
-	LDFLAGS='-static' \
 	CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	CPPFLAGS_FOR_TARGET='-g -O2 -gdwarf-3 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	--target=tricore-elf \
@@ -289,7 +285,6 @@ if [[ $* == *--binutils-mcs-win* || $* == *--all* ]]; then
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/binutils-mcs-win
 	if ! $BINUTILS_SRC_FOLDER/configure \
-	LDFLAGS='-static' \
 	--target=mcs-elf \
 	--host=x86_64-w64-mingw32 \
 	--program-prefix=mcs-elf- \
@@ -316,7 +311,7 @@ if [[ $* == *--binutils-mcs-win* || $* == *--all* ]]; then
 		echo "The build has failed during configure of binutils-mcs for Windows"
 		exit 1
 	fi
-        make --output-sync -j${PARALLEL_JOBS} LDFLAGS="-static" 2>&1 | tee $LOG_FOLDER/binutils_mcs-win.log
+        make --output-sync -j${PARALLEL_JOBS} 2>&1 | tee $LOG_FOLDER/binutils_mcs-win.log
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during make of binutils-mcs for Windows"
 		exit 1
@@ -339,7 +334,6 @@ if [[ $* == *--binutils-win* || $* == *--all* ]]; then
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/binutils-win
 	if ! $BINUTILS_SRC_FOLDER/configure \
-	LDFLAGS='-static' \
 	--target=tricore-elf \
 	--host=x86_64-w64-mingw32 \
 	--enable-targets=mcs-elf \
@@ -367,7 +361,7 @@ if [[ $* == *--binutils-win* || $* == *--all* ]]; then
 		echo "The build has failed during configure of binutils fow Windows"
 		exit 1
 	fi
-	make --output-sync -j${PARALLEL_JOBS} LDFLAGS="-static" 2>&1 | tee $LOG_FOLDER/binutils-win.log
+	make --output-sync -j${PARALLEL_JOBS} 2>&1 | tee $LOG_FOLDER/binutils-win.log
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during make of binutils for Windows"
 		exit 1
@@ -391,7 +385,6 @@ if [[ $* == "--gcc-stage2-win" || $* == *--all* ]]; then
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/gcc-stage2-win
 	if ! $GCC_SRC_FOLDER/configure \
-	LDFLAGS='-static' \
 	CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	CPPFLAGS_FOR_TARGET='-g -O2 -gdwarf-3 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	--target=tricore-elf \

--- a/build-toolchain
+++ b/build-toolchain
@@ -1,43 +1,81 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-export TOOLCHAIN_ROOT="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-export INSTALL_FOLDER=$TOOLCHAIN_ROOT/INSTALL
-export INSTALL_FOLDER_WIN=$TOOLCHAIN_ROOT/INSTALL-WIN
-export BUILD_FOLDER=$TOOLCHAIN_ROOT/BUILD
-export LOG_FOLDER=$TOOLCHAIN_ROOT/LOG
-export SCRIPTS=$TOOLCHAIN_ROOT/build_scripts
-export PATH=$INSTALL_FOLDER/bin:$PATH
+set -eu
+
+TOOLCHAIN_ROOT="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+INSTALL_FOLDER=$TOOLCHAIN_ROOT/INSTALL
+INSTALL_FOLDER_WIN=$TOOLCHAIN_ROOT/INSTALL-WIN
+BUILD_FOLDER=$TOOLCHAIN_ROOT/BUILD
+LOG_FOLDER=$TOOLCHAIN_ROOT/LOG
 PARALLEL_JOBS=$(nproc)
-#PARALLEL_JOBS=1
 
+export PATH="$INSTALL_FOLDER/bin:$PATH"
 
+# set default build flags if not available in env
+CFLAGS="${CFLAGS:--O2}"
+CXXFLAGS="${CXXFLAGS:--O2}"
+LDFLAGS="${LDFLAGS:--static -s}"
 
-if [[ $* == *--help* || $* == *-h* ]]; then
-	echo "Usage: build-toolchain [--all] [--binutils-mcs] [--binutils] [--gcc-stage1] [--newlib] [--gcc-stage2] [--clean-all] [--clean-binutils-mcs] [--clean-binutils] [--clean-gcc-stage1] [--clean-newlib] [--clean-gcc-stage2] [--clean-binutils-mcs-win] [--binutils-mcs-win] [--clean-binutils-win] [--binutils-win] [--clean-gcc-stage2-win] [--gcc-stage2-win] [--help | -h]"
-	exit 0
-fi
+print_usage() {
+	cat <<EOF
+build-toolchain [--help | -h] [-o step] [--clean-all]
 
+options:
+  -h, --help             Show this help message and exit
+  -o step, --only step   Build only specific build step
+  -c, --clean            Perform clean of the selected step (default=all)
+  -b, --build            Perform build of the selected step (default=all)
+  --clean-all            Delete all build and install folders
 
+Supported build steps are: [all, binutils-mcs, binutils-tc, gcc-stage1, newlib, gcc-stage2,
+binutils-mcs-win, binutils-tc-win, gcc-stage2-win]
+EOF
+	exit
+}
 
-if [[ $* == *--clean-all* ]]; then
-	rm -fr $BUILD_FOLDER
-	rm -fr $LOG_FOLDER
-fi
+clean_all_artifacts() {
+	rm -fr "$INSTALL_FOLDER" "$INSTALL_FOLDER_WIN" "$BUILD_FOLDER" "$LOG_FOLDER"
+	exit
+}
 
+parse_params() {
+	build_step="all"
+	build_task="build"
+
+	while :; do
+    	case "${1-}" in
+    	-h | --help) print_usage ;;
+		--clean-all) clean_all_artifacts ;;
+		-c | --clean) build_task="clean" ;;
+		-b | --build) build_task="build" ;;
+		-o | --only-step)
+		build_step="${2-}"
+		shift
+		;;
+    	-?*) echo "Unknown option: $1" ;;
+    *) break ;;
+    esac
+    shift
+  	done
+}
+
+parse_params "$@"
+task_string="$build_task-$build_step"
 
 ### Binutils MCS
 
-if [[ $* == "--clean-binutils-mcs" ]]; then
-	rm -fr $BUILD_FOLDER/binutils-mcs
+if [[ "$task_string" == "clean-binutils-mcs" || "$task_string" == "clean-all" ]]; then
+	echo "Deleting $BUILD_FOLDER/binutils-mcs..."
+	rm -fr "$BUILD_FOLDER/binutils-mcs"
 fi
 
-if [[ $* == "--binutils-mcs" || $* == *--all* ]]; then
-	export BINUTILS_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-binutils-gdb
-	mkdir -p $BUILD_FOLDER/binutils-mcs
-	mkdir -p $LOG_FOLDER
-	cd $BUILD_FOLDER/binutils-mcs
+if [[ "$task_string" == "build-binutils-mcs" || "$task_string" == "build-all" ]]; then
+	BINUTILS_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-binutils-gdb
+	mkdir -p "$BUILD_FOLDER/binutils-mcs"
+	mkdir -p "$LOG_FOLDER"
+	cd "$BUILD_FOLDER/binutils-mcs"
 	if ! $BINUTILS_SRC_FOLDER/configure \
-	LDFLAGS='-static' \
+	LDFLAGS="$LDFLAGS" \
 	--target=mcs-elf \
 	--program-prefix=mcs-elf- \
 	--disable-threads \
@@ -58,17 +96,17 @@ if [[ $* == "--binutils-mcs" || $* == *--all* ]]; then
 	--enable-checking=release \
 	--with-gnu-ld \
 	--with-gnu-as \
-	--prefix=$INSTALL_FOLDER \
+	--prefix="$INSTALL_FOLDER" \
 	--disable-werror; then
 		echo "The build has failed during configure of binutils-mcs"
 		exit 1
 	fi
-        make --output-sync -j${PARALLEL_JOBS} LDFLAGS="-static" 2>&1 | tee $LOG_FOLDER/binutils_mcs.log
+        make --output-sync -j${PARALLEL_JOBS} LDFLAGS="$LDFLAGS" 2>&1 | tee "$LOG_FOLDER/binutils_mcs.log"
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during make of binutils-mcs"
 		exit 1
 	fi
-	make install 2>&1 | tee -a $LOG_FOLDER/binutils_mcs.log
+	make install 2>&1 | tee -a "$LOG_FOLDER/binutils_mcs.log"
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during install of binutils-mcs"
 		exit 1
@@ -78,17 +116,18 @@ fi
 
 ### Binutils
 
-if [[ $* == *--clean-binutils* ]]; then
-	rm -fr $BUILD_FOLDER/binutils
+if [[ "$task_string" == "clean-binutils-tc" || "$task_string" == "clean-all" ]]; then
+	echo "Deleting $BUILD_FOLDER/binutils-tc..."
+	rm -fr "$BUILD_FOLDER/binutils-tc"
 fi
 
-if [[ $* == "--binutils" || $* == *--all* ]]; then
-	export BINUTILS_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-binutils-gdb
-	mkdir -p $BUILD_FOLDER/binutils
-	mkdir -p $LOG_FOLDER
-	cd $BUILD_FOLDER/binutils
+if [[ "$task_string" == "build-binutils-tc" || "$task_string" == "build-all" ]]; then
+	BINUTILS_SRC_FOLDER="$TOOLCHAIN_ROOT/tricore-binutils-gdb"
+	mkdir -p "$BUILD_FOLDER/binutils-tc"
+	mkdir -p "$LOG_FOLDER"
+	cd "$BUILD_FOLDER/binutils-tc"
 	if ! $BINUTILS_SRC_FOLDER/configure \
-	LDFLAGS='-static' \
+	LDFLAGS="$LDFLAGS" \
 	--target=tricore-elf \
 	--enable-targets=mcs-elf \
 	--program-prefix=tricore-elf- \
@@ -110,17 +149,17 @@ if [[ $* == "--binutils" || $* == *--all* ]]; then
 	--enable-checking=release \
 	--with-gnu-ld \
 	--with-gnu-as \
-	--prefix=$INSTALL_FOLDER \
+	--prefix="$INSTALL_FOLDER" \
 	--disable-werror; then
 		echo "The build has failed during configure of binutils"
 		exit 1
 	fi
-	make --output-sync -j${PARALLEL_JOBS} LDFLAGS="-static" 2>&1 | tee $LOG_FOLDER/binutils.log
+	make --output-sync -j${PARALLEL_JOBS} LDFLAGS="$LDFLAGS" 2>&1 | tee "$LOG_FOLDER/binutils.log"
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during make of binutils"
 		exit 1
 	fi
-	make install 2>&1 | tee -a  $LOG_FOLDER/binutils.log
+	make install 2>&1 | tee -a  "$LOG_FOLDER/binutils.log"
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during install of binutils"
 		exit 1
@@ -130,28 +169,29 @@ fi
 
 ### GCC stage1
 
-if [[ $* == *--clean-gcc-stage1* ]]; then
-	rm -fr $BUILD_FOLDER/gcc-stage1
+if [[ "$task_string" == "clean-gcc-stage1" || "$task_string" == "clean-all" ]]; then
+	echo "Deleting $BUILD_FOLDER/gcc-stage1..."
+	rm -fr "$BUILD_FOLDER/gcc-stage1"
 fi
 
-if [[ $* == *--gcc-stage1* || $* == *--all* ]]; then
-	export GCC_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-gcc
-	#Download necessary dependencies if they don't exist
+if [[ "$task_string" == "build-gcc-stage1" || "$task_string" == "build-all" ]]; then
+	GCC_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-gcc
+	# Download necessary dependencies if they don't exist
 	if [[ ! -d $GCC_SRC_FOLDER/gmp ]]; then
-		cd -- $GCC_SRC_FOLDER
+		cd -- "$GCC_SRC_FOLDER"
 		./contrib/download_prerequisites
 	fi
-	mkdir -p $BUILD_FOLDER/gcc-stage1
-	mkdir -p $LOG_FOLDER
-	cd $BUILD_FOLDER/gcc-stage1
+	mkdir -p "$BUILD_FOLDER/gcc-stage1"
+	mkdir -p "$LOG_FOLDER"
+	cd "$BUILD_FOLDER/gcc-stage1"
 	if ! $GCC_SRC_FOLDER/configure \
-	LDFLAGS='-static' \
+	LDFLAGS="$LDFLAGS" \
 	CFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
 	CXXFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
 	--target=tricore-elf \
 	--enable-lib32 \
 	--disable-lib64 \
-	--prefix=$INSTALL_FOLDER \
+	--prefix="$INSTALL_FOLDER" \
 	--enable-languages=c,c++ \
 	--enable-libstdcxx-debug-flags='-gdwarf-3 -g -O0 -D_GLIBCXX_ASSERTIONS' \
 	--enable-c99 \
@@ -173,12 +213,12 @@ if [[ $* == *--gcc-stage1* || $* == *--all* ]]; then
 		echo "The build has failed during configure of gcc (stage 1)"
 		exit 1
 	fi
-	make -j${PARALLEL_JOBS} all-gcc 2>&1 | tee $LOG_FOLDER/gcc_stage1.log
+	make -j${PARALLEL_JOBS} all-gcc 2>&1 | tee "$LOG_FOLDER/gcc_stage1.log"
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during make of gcc (stage 1)"
 		exit 1
 	fi
-	make install-gcc 2>&1 | tee -a $LOG_FOLDER/gcc_stage1.log
+	make install-gcc 2>&1 | tee -a "$LOG_FOLDER/gcc_stage1.log"
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during install of gcc (stage 1)"
 		exit 1
@@ -188,15 +228,16 @@ fi
 
 ### Newlib
 
-if [[ $* == *--clean-newlib* ]]; then
-	rm -fr $BUILD_FOLDER/newlib
+if [[ "$task_string" == "clean-newlib" || "$task_string" == "clean-all" ]]; then
+	echo "Deleting $BUILD_FOLDER/newlib..."
+	rm -fr "$BUILD_FOLDER/newlib"
 fi
 
-if [[ $* == *--newlib* || $* == *--all* ]]; then
-	export NEWLIB_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-newlib-cygwin
-	mkdir -p $BUILD_FOLDER/newlib
-	mkdir -p $LOG_FOLDER
-	cd $BUILD_FOLDER/newlib
+if [[ "$task_string" == "build-newlib" || "$task_string" == "build-all" ]]; then
+	NEWLIB_SRC_FOLDER="$TOOLCHAIN_ROOT/tricore-newlib-cygwin"
+	mkdir -p "$BUILD_FOLDER/newlib"
+	mkdir -p "$LOG_FOLDER"
+	cd "$BUILD_FOLDER/newlib"
 	export CC_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-gcc
 	export CXX_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-c++
 	export GCC_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-gcc
@@ -214,42 +255,42 @@ if [[ $* == *--newlib* || $* == *--all* ]]; then
 	--target=tricore-elf \
 	--host=i686-w64-mingw32 \
 	--build=i686-pc-mingw32 \
-	--prefix=$INSTALL_FOLDER; then
+	--prefix="$INSTALL_FOLDER"; then
 		echo "The build has failed during configure of newlib"
 		exit 1
 	fi
-	make -j${PARALLEL_JOBS} LDFLAGS="-static" all 2>&1 | tee $LOG_FOLDER/newlib.log
+	make -j${PARALLEL_JOBS} LDFLAGS="$LDFLAGS" all 2>&1 | tee "$LOG_FOLDER/newlib.log"
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during make of newlib"
 	fi
-	make install 2>&1 | tee -a $LOG_FOLDER/newlib.log
-	make install prefix=$INSTALL_FOLDER_WIN 2>&1 | tee -a $LOG_FOLDER/newlib-win.log
+	make install 2>&1 | tee -a "$LOG_FOLDER/newlib.log"
+	make install prefix=$INSTALL_FOLDER_WIN 2>&1 | tee -a "$LOG_FOLDER/newlib-win.log"
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during install of newlib"
 		exit 1
 	fi
 fi
 
-
 ### GCC stage2
 
-if [[ $* == *--clean-gcc-stage2* ]]; then
-	rm -fr $BUILD_FOLDER/gcc-stage2
+if [[ "$task_string" == "clean-gcc-stage2" || "$task_string" == "clean-all" ]]; then
+	echo "Deleting $BUILD_FOLDER/gcc-stage2..."
+	rm -fr "$BUILD_FOLDER/gcc-stage2"
 fi
 
-if [[ $* == "--gcc-stage2" || $* == *--all* ]]; then
+if [[ "$task_string" == "build-gcc-stage2" || "$task_string" == "build-all" ]]; then
 	export GCC_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-gcc
-	mkdir -p $BUILD_FOLDER/gcc-stage2
-	mkdir -p $LOG_FOLDER
-	cd $BUILD_FOLDER/gcc-stage2
+	mkdir -p "$BUILD_FOLDER/gcc-stage2"
+	mkdir -p "$LOG_FOLDER"
+	cd "$BUILD_FOLDER/gcc-stage2"
 	if ! $GCC_SRC_FOLDER/configure \
-	LDFLAGS='-static' \
+	LDFLAGS="$LDFLAGS" \
 	CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	CPPFLAGS_FOR_TARGET='-g -O2 -gdwarf-3 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	--target=tricore-elf \
 	--enable-lib32 \
 	--disable-lib64 \
-	--prefix=$INSTALL_FOLDER \
+	--prefix="$INSTALL_FOLDER" \
 	--enable-languages=c,c++ \
 	--enable-libstdcxx-debug-flags='-gdwarf-3 -g -O0 -D_GLIBCXX_ASSERTIONS' \
 	--enable-c99 \
@@ -273,29 +314,30 @@ if [[ $* == "--gcc-stage2" || $* == *--all* ]]; then
 		echo "The build has failed during configure of gcc (stage 2)"
 		exit 1
 	fi
-	make -j${PARALLEL_JOBS} all 2>&1 | tee $LOG_FOLDER/gcc_stage2.log
+	make -j${PARALLEL_JOBS} all 2>&1 | tee "$LOG_FOLDER/gcc_stage2.log"
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during make of gcc (stage 2)"
 		exit 1
 	fi
-	make install-strip 2>&1 | tee -a $LOG_FOLDER/gcc_stage2.log
+	make install-strip 2>&1 | tee -a "$LOG_FOLDER/gcc_stage2.log"
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during install of gcc (stage 2)"
 		exit 1
 	fi
 fi
 
-if [[ $* == *--clean-binutils-mcs-win* ]]; then
-	rm -fr $BUILD_FOLDER/binutils-mcs-win
+if [[ "$task_string" == "clean-binutils-mcs-win" || "$task_string" == "clean-all" ]]; then
+	echo "Deleting $BUILD_FOLDER/binutils-mcs-win..."
+	rm -fr "$BUILD_FOLDER/binutils-mcs-win"
 fi
 
-if [[ $* == *--binutils-mcs-win* || $* == *--all* ]]; then
+if [[ "$task_string" == "build-binutils-mcs-win" || "$task_string" == "build-all" ]]; then
 	export BINUTILS_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-binutils-gdb
-	mkdir -p $BUILD_FOLDER/binutils-mcs-win
-	mkdir -p $LOG_FOLDER
-	cd $BUILD_FOLDER/binutils-mcs-win
+	mkdir -p "$BUILD_FOLDER/binutils-mcs-win"
+	mkdir -p "$LOG_FOLDER"
+	cd "$BUILD_FOLDER/binutils-mcs-win"
 	if ! $BINUTILS_SRC_FOLDER/configure \
-	LDFLAGS='-static' \
+	LDFLAGS="$LDFLAGS" \
 	--target=mcs-elf \
 	--host=x86_64-w64-mingw32 \
 	--program-prefix=mcs-elf- \
@@ -317,17 +359,17 @@ if [[ $* == *--binutils-mcs-win* || $* == *--all* ]]; then
 	--enable-checking=release \
 	--with-gnu-ld \
 	--with-gnu-as \
-	--prefix=$INSTALL_FOLDER_WIN \
+	--prefix="$INSTALL_FOLDER_WIN" \
 	--disable-werror; then
 		echo "The build has failed during configure of binutils-mcs for Windows"
 		exit 1
 	fi
-        make --output-sync -j${PARALLEL_JOBS} 2>&1 | tee $LOG_FOLDER/binutils_mcs-win.log
+        make --output-sync -j${PARALLEL_JOBS} 2>&1 | tee "$LOG_FOLDER/binutils_mcs-win.log"
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during make of binutils-mcs for Windows"
 		exit 1
 	fi
-	make install 2>&1 | tee -a $LOG_FOLDER/binutils_mcs-win.log
+	make install 2>&1 | tee -a "$LOG_FOLDER/binutils_mcs-win.log"
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during install of binutils-mcs for Windows"
 		exit 1
@@ -335,17 +377,18 @@ if [[ $* == *--binutils-mcs-win* || $* == *--all* ]]; then
 fi
 
 
-if [[ $* == *--clean-binutils-win* ]]; then
-	rm -fr $BUILD_FOLDER/binutils-win
+if [[ "$task_string" == "clean-binutils-tc-win" || "$task_string" == "clean-all" ]]; then
+	echo "Deleting $BUILD_FOLDER/binutils-tc-win..."
+	rm -fr "$BUILD_FOLDER/binutils-tc-win"
 fi
 
-if [[ $* == *--binutils-win* || $* == *--all* ]]; then
-	export BINUTILS_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-binutils-gdb
-	mkdir -p $BUILD_FOLDER/binutils-win
-	mkdir -p $LOG_FOLDER
-	cd $BUILD_FOLDER/binutils-win
+if [[ "$task_string" == "build-binutils-tc-win" || "$task_string" == "build-all" ]]; then
+	BINUTILS_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-binutils-gdb
+	mkdir -p "$BUILD_FOLDER/binutils-tc-win"
+	mkdir -p "$LOG_FOLDER"
+	cd "$BUILD_FOLDER/binutils-tc-win"
 	if ! $BINUTILS_SRC_FOLDER/configure \
-	LDFLAGS='-static' \
+	LDFLAGS="$LDFLAGS" \
 	--target=tricore-elf \
 	--host=x86_64-w64-mingw32 \
 	--enable-targets=mcs-elf \
@@ -368,17 +411,17 @@ if [[ $* == *--binutils-win* || $* == *--all* ]]; then
 	--enable-checking=release \
 	--with-gnu-ld \
 	--with-gnu-as \
-	--prefix=$INSTALL_FOLDER_WIN \
+	--prefix="$INSTALL_FOLDER_WIN" \
 	--disable-werror; then
 		echo "The build has failed during configure of binutils fow Windows"
 		exit 1
 	fi
-	make --output-sync -j${PARALLEL_JOBS} 2>&1 | tee $LOG_FOLDER/binutils-win.log
+	make --output-sync -j${PARALLEL_JOBS} 2>&1 | tee "$LOG_FOLDER/binutils-tc-win.log"
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during make of binutils for Windows"
 		exit 1
 	fi
-	make install 2>&1 | tee -a  $LOG_FOLDER/binutils-win.log
+	make install 2>&1 | tee -a  "$LOG_FOLDER/binutils-tc-win.log"
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during install of binutils for Windows"
 		exit 1
@@ -387,24 +430,25 @@ fi
 
 
 
-if [[ $* == *--clean-gcc-stage2-win* ]]; then
-	rm -fr $BUILD_FOLDER/gcc-stage2
+if [[ "$task_string" == "clean-gcc-stage2-win" || "$task_string" == "clean-all" ]]; then
+	echo "Deleting $BUILD_FOLDER/gcc-stage2-win..."
+	rm -fr "$BUILD_FOLDER/gcc-stage2-win"
 fi
 
-if [[ $* == "--gcc-stage2-win" || $* == *--all* ]]; then
-	export GCC_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-gcc
-	mkdir -p $BUILD_FOLDER/gcc-stage2-win
-	mkdir -p $LOG_FOLDER
-	cd $BUILD_FOLDER/gcc-stage2-win
+if [[ "$task_string" == "build-gcc-stage2-win" || "$task_string" == "build-all" ]]; then
+	GCC_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-gcc
+	mkdir -p "$BUILD_FOLDER/gcc-stage2-win"
+	mkdir -p "$LOG_FOLDER"
+	cd "$BUILD_FOLDER/gcc-stage2-win"
 	if ! $GCC_SRC_FOLDER/configure \
-	LDFLAGS='-static' \
+	LDFLAGS="$LDFLAGS" \
 	CFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	CPPFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	--target=tricore-elf \
 	--host=x86_64-w64-mingw32 \
 	--enable-lib32 \
 	--disable-lib64 \
-	--prefix=$INSTALL_FOLDER_WIN \
+	--prefix="$INSTALL_FOLDER_WIN" \
 	--enable-languages=c,c++ \
 	--enable-libstdcxx-debug-flags='-gdwarf-3 -g -O0 -D_GLIBCXX_ASSERTIONS' \
 	--enable-c99 \
@@ -428,12 +472,12 @@ if [[ $* == "--gcc-stage2-win" || $* == *--all* ]]; then
 		echo "The build has failed during configure of gcc (stage 2) for Windows"
 		exit 1
 	fi
-	make -j${PARALLEL_JOBS} all 2>&1 | tee $LOG_FOLDER/gcc_stage2-win.log
+	make -j${PARALLEL_JOBS} all 2>&1 | tee "$LOG_FOLDER/gcc_stage2-win.log"
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during make of gcc (stage 2) for Windows"
 		exit 1
 	fi
-	make install-strip 2>&1 | tee -a $LOG_FOLDER/gcc_stage2-win.log
+	make install-strip 2>&1 | tee -a "$LOG_FOLDER/gcc_stage2-win.log"
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during install of gcc (stage 2) for Windows"
 		exit 1

--- a/build-toolchain
+++ b/build-toolchain
@@ -28,7 +28,8 @@ options:
   --clean-all            Delete all build and install folders
 
 Supported build steps are:
-  all               Build both windows and linux toolchains
+  all               Build both windows and linux toolchains (compiler + binutils + newlib)
+  linux             Build linux toolchain (compiler + binutils + newlib)
   binutils-mcs      Build MCS version of binutils for linux
   binutils-tc       Build Tricore version of binutils for linux
   gcc-stage1        Build stage1 GCC compiler for linux
@@ -72,12 +73,12 @@ task_string="$build_task-$build_step"
 
 ### Binutils MCS
 
-if [[ "$task_string" == "clean-binutils-mcs" || "$task_string" == "clean-all" ]]; then
+if [[ "$task_string" == "clean-binutils-mcs" || "$task_string" == "clean-all" || "$task_string" == "clean-linux" ]]; then
     echo "Deleting $BUILD_FOLDER/binutils-mcs..."
     rm -fr "$BUILD_FOLDER/binutils-mcs"
 fi
 
-if [[ "$task_string" == "build-binutils-mcs" || "$task_string" == "build-all" ]]; then
+if [[ "$task_string" == "build-binutils-mcs" || "$task_string" == "build-all" || "$task_string" == "build-linux" ]]; then
     BINUTILS_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-binutils-gdb
     mkdir -p "$BUILD_FOLDER/binutils-mcs"
     mkdir -p "$LOG_FOLDER"
@@ -126,12 +127,12 @@ fi
 
 ### Binutils
 
-if [[ "$task_string" == "clean-binutils-tc" || "$task_string" == "clean-all" ]]; then
+if [[ "$task_string" == "clean-binutils-tc" || "$task_string" == "clean-all" || "$task_string" == "clean-linux" ]]; then
     echo "Deleting $BUILD_FOLDER/binutils-tc..."
     rm -fr "$BUILD_FOLDER/binutils-tc"
 fi
 
-if [[ "$task_string" == "build-binutils-tc" || "$task_string" == "build-all" ]]; then
+if [[ "$task_string" == "build-binutils-tc" || "$task_string" == "build-all" || "$task_string" == "build-linux" ]]; then
     BINUTILS_SRC_FOLDER="$TOOLCHAIN_ROOT/tricore-binutils-gdb"
     mkdir -p "$BUILD_FOLDER/binutils-tc"
     mkdir -p "$LOG_FOLDER"
@@ -181,12 +182,12 @@ fi
 
 ### GCC stage1
 
-if [[ "$task_string" == "clean-gcc-stage1" || "$task_string" == "clean-all" ]]; then
+if [[ "$task_string" == "clean-gcc-stage1" || "$task_string" == "clean-all" || "$task_string" == "clean-linux" ]]; then
     echo "Deleting $BUILD_FOLDER/gcc-stage1..."
     rm -fr "$BUILD_FOLDER/gcc-stage1"
 fi
 
-if [[ "$task_string" == "build-gcc-stage1" || "$task_string" == "build-all" ]]; then
+if [[ "$task_string" == "build-gcc-stage1" || "$task_string" == "build-all" || "$task_string" == "build-linux" ]]; then
     GCC_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-gcc
     # Download necessary dependencies if they don't exist
     if [[ ! -d $GCC_SRC_FOLDER/gmp ]]; then
@@ -242,12 +243,12 @@ fi
 
 ### Newlib
 
-if [[ "$task_string" == "clean-newlib" || "$task_string" == "clean-all" ]]; then
+if [[ "$task_string" == "clean-newlib" || "$task_string" == "clean-all" || "$task_string" == "clean-linux" ]]; then
     echo "Deleting $BUILD_FOLDER/newlib..."
     rm -fr "$BUILD_FOLDER/newlib"
 fi
 
-if [[ "$task_string" == "build-newlib" || "$task_string" == "build-all" ]]; then
+if [[ "$task_string" == "build-newlib" || "$task_string" == "build-all" || "$task_string" == "build-linux" ]]; then
     NEWLIB_SRC_FOLDER="$TOOLCHAIN_ROOT/tricore-newlib-cygwin"
     mkdir -p "$BUILD_FOLDER/newlib"
     mkdir -p "$LOG_FOLDER"
@@ -287,12 +288,12 @@ fi
 
 ### GCC stage2
 
-if [[ "$task_string" == "clean-gcc-stage2" || "$task_string" == "clean-all" ]]; then
+if [[ "$task_string" == "clean-gcc-stage2" || "$task_string" == "clean-all" || "$task_string" == "clean-linux" ]]; then
     echo "Deleting $BUILD_FOLDER/gcc-stage2..."
     rm -fr "$BUILD_FOLDER/gcc-stage2"
 fi
 
-if [[ "$task_string" == "build-gcc-stage2" || "$task_string" == "build-all" ]]; then
+if [[ "$task_string" == "build-gcc-stage2" || "$task_string" == "build-all" || "$task_string" == "build-linux" ]]; then
     export GCC_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-gcc
     mkdir -p "$BUILD_FOLDER/gcc-stage2"
     mkdir -p "$LOG_FOLDER"

--- a/build-toolchain
+++ b/build-toolchain
@@ -37,6 +37,7 @@ if [[ $* == "--binutils-mcs" || $* == *--all* ]]; then
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/binutils-mcs
 	if ! $BINUTILS_SRC_FOLDER/configure \
+	LDFLAGS='-static' \
 	--target=mcs-elf \
 	--program-prefix=mcs-elf- \
 	--disable-threads \
@@ -62,7 +63,7 @@ if [[ $* == "--binutils-mcs" || $* == *--all* ]]; then
 		echo "The build has failed during configure of binutils-mcs"
 		exit 1
 	fi
-        make --output-sync -j${PARALLEL_JOBS} 2>&1 | tee $LOG_FOLDER/binutils_mcs.log
+        make --output-sync -j${PARALLEL_JOBS} LDFLAGS="-static" 2>&1 | tee $LOG_FOLDER/binutils_mcs.log
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during make of binutils-mcs"
 		exit 1
@@ -87,6 +88,7 @@ if [[ $* == "--binutils" || $* == *--all* ]]; then
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/binutils
 	if ! $BINUTILS_SRC_FOLDER/configure \
+	LDFLAGS='-static' \
 	--target=tricore-elf \
 	--enable-targets=mcs-elf \
 	--program-prefix=tricore-elf- \
@@ -113,7 +115,7 @@ if [[ $* == "--binutils" || $* == *--all* ]]; then
 		echo "The build has failed during configure of binutils"
 		exit 1
 	fi
-	make --output-sync -j${PARALLEL_JOBS} 2>&1 | tee $LOG_FOLDER/binutils.log
+	make --output-sync -j${PARALLEL_JOBS} LDFLAGS="-static" 2>&1 | tee $LOG_FOLDER/binutils.log
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during make of binutils"
 		exit 1
@@ -138,6 +140,7 @@ if [[ $* == *--gcc-stage1* || $* == *--all* ]]; then
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/gcc-stage1
 	if ! $GCC_SRC_FOLDER/configure \
+	LDFLAGS='-static' \
 	CFLAGS_FOR_TARGET='-O2 -gdwarf-3' \
 	CXXFLAGS_FOR_TARGET='-O2 -gdwarf-3' \
 	--target=tricore-elf \
@@ -210,7 +213,7 @@ if [[ $* == *--newlib* || $* == *--all* ]]; then
 		echo "The build has failed during configure of newlib"
 		exit 1
 	fi
-	make -j${PARALLEL_JOBS} all 2>&1 | tee $LOG_FOLDER/newlib.log
+	make -j${PARALLEL_JOBS} LDFLAGS="-static" all 2>&1 | tee $LOG_FOLDER/newlib.log
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during make of newlib"
 	fi
@@ -234,6 +237,7 @@ if [[ $* == "--gcc-stage2" || $* == *--all* ]]; then
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/gcc-stage2
 	if ! $GCC_SRC_FOLDER/configure \
+	LDFLAGS='-static' \
 	CFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	CPPFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	--target=tricore-elf \
@@ -285,6 +289,7 @@ if [[ $* == *--binutils-mcs-win* || $* == *--all* ]]; then
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/binutils-mcs-win
 	if ! $BINUTILS_SRC_FOLDER/configure \
+	LDFLAGS='-static' \
 	--target=mcs-elf \
 	--host=x86_64-w64-mingw32 \
 	--program-prefix=mcs-elf- \
@@ -334,6 +339,7 @@ if [[ $* == *--binutils-win* || $* == *--all* ]]; then
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/binutils-win
 	if ! $BINUTILS_SRC_FOLDER/configure \
+	LDFLAGS='-static' \
 	--target=tricore-elf \
 	--host=x86_64-w64-mingw32 \
 	--enable-targets=mcs-elf \
@@ -385,6 +391,7 @@ if [[ $* == "--gcc-stage2-win" || $* == *--all* ]]; then
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/gcc-stage2-win
 	if ! $GCC_SRC_FOLDER/configure \
+	LDFLAGS='-static' \
 	CFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	CPPFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	--target=tricore-elf \

--- a/build-toolchain
+++ b/build-toolchain
@@ -76,6 +76,8 @@ if [[ "$task_string" == "build-binutils-mcs" || "$task_string" == "build-all" ]]
 	cd "$BUILD_FOLDER/binutils-mcs"
 	if ! $BINUTILS_SRC_FOLDER/configure \
 	LDFLAGS="$LDFLAGS" \
+	CFLAGS="$CFLAGS" \
+	CXXFLAGS="$CXXFLAGS" \
 	--target=mcs-elf \
 	--program-prefix=mcs-elf- \
 	--disable-threads \
@@ -128,6 +130,8 @@ if [[ "$task_string" == "build-binutils-tc" || "$task_string" == "build-all" ]];
 	cd "$BUILD_FOLDER/binutils-tc"
 	if ! $BINUTILS_SRC_FOLDER/configure \
 	LDFLAGS="$LDFLAGS" \
+	CFLAGS="$CFLAGS" \
+	CXXFLAGS="$CXXFLAGS" \
 	--target=tricore-elf \
 	--enable-targets=mcs-elf \
 	--program-prefix=tricore-elf- \
@@ -186,6 +190,8 @@ if [[ "$task_string" == "build-gcc-stage1" || "$task_string" == "build-all" ]]; 
 	cd "$BUILD_FOLDER/gcc-stage1"
 	if ! $GCC_SRC_FOLDER/configure \
 	LDFLAGS="$LDFLAGS" \
+	CFLAGS="$CFLAGS" \
+	CXXFLAGS="$CXXFLAGS" \
 	CFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
 	CXXFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
 	--target=tricore-elf \
@@ -285,6 +291,8 @@ if [[ "$task_string" == "build-gcc-stage2" || "$task_string" == "build-all" ]]; 
 	cd "$BUILD_FOLDER/gcc-stage2"
 	if ! $GCC_SRC_FOLDER/configure \
 	LDFLAGS="$LDFLAGS" \
+	CFLAGS="$CFLAGS" \
+	CXXFLAGS="$CXXFLAGS" \
 	CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	CPPFLAGS_FOR_TARGET='-g -O2 -gdwarf-3 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	--target=tricore-elf \
@@ -338,6 +346,8 @@ if [[ "$task_string" == "build-binutils-mcs-win" || "$task_string" == "build-all
 	cd "$BUILD_FOLDER/binutils-mcs-win"
 	if ! $BINUTILS_SRC_FOLDER/configure \
 	LDFLAGS="$LDFLAGS" \
+	CFLAGS="$CFLAGS" \
+	CXXFLAGS="$CXXFLAGS" \
 	--target=mcs-elf \
 	--host=x86_64-w64-mingw32 \
 	--program-prefix=mcs-elf- \
@@ -389,6 +399,8 @@ if [[ "$task_string" == "build-binutils-tc-win" || "$task_string" == "build-all"
 	cd "$BUILD_FOLDER/binutils-tc-win"
 	if ! $BINUTILS_SRC_FOLDER/configure \
 	LDFLAGS="$LDFLAGS" \
+	CFLAGS="$CFLAGS" \
+	CXXFLAGS="$CXXFLAGS" \
 	--target=tricore-elf \
 	--host=x86_64-w64-mingw32 \
 	--enable-targets=mcs-elf \
@@ -442,6 +454,8 @@ if [[ "$task_string" == "build-gcc-stage2-win" || "$task_string" == "build-all" 
 	cd "$BUILD_FOLDER/gcc-stage2-win"
 	if ! $GCC_SRC_FOLDER/configure \
 	LDFLAGS="$LDFLAGS" \
+	CFLAGS="$CFLAGS" \
+	CXXFLAGS="$CXXFLAGS" \
 	CFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	CPPFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	--target=tricore-elf \

--- a/build-toolchain
+++ b/build-toolchain
@@ -268,7 +268,7 @@ if [[ $* == "--gcc-stage2" || $* == *--all* ]]; then
 		echo "The build has failed during make of gcc (stage 2)"
 		exit 1
 	fi
-	make install 2>&1 | tee -a $LOG_FOLDER/gcc_stage2.log
+	make install-strip 2>&1 | tee -a $LOG_FOLDER/gcc_stage2.log
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during install of gcc (stage 2)"
 		exit 1
@@ -420,7 +420,7 @@ if [[ $* == "--gcc-stage2-win" || $* == *--all* ]]; then
 		echo "The build has failed during make of gcc (stage 2) for Windows"
 		exit 1
 	fi
-	make install 2>&1 | tee -a $LOG_FOLDER/gcc_stage2-win.log
+	make install-strip 2>&1 | tee -a $LOG_FOLDER/gcc_stage2-win.log
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during install of gcc (stage 2) for Windows"
 		exit 1

--- a/build-toolchain
+++ b/build-toolchain
@@ -2,6 +2,7 @@
 
 export TOOLCHAIN_ROOT="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 export INSTALL_FOLDER=$TOOLCHAIN_ROOT/INSTALL
+export INSTALL_FOLDER_WIN=$TOOLCHAIN_ROOT/INSTALL-WIN
 export BUILD_FOLDER=$TOOLCHAIN_ROOT/BUILD
 export LOG_FOLDER=$TOOLCHAIN_ROOT/LOG
 export SCRIPTS=$TOOLCHAIN_ROOT/build_scripts
@@ -12,7 +13,7 @@ PARALLEL_JOBS=$(nproc)
 
 
 if [[ $* == *--help* || $* == *-h* ]]; then
-	echo "Usage: build-toolchain [--all] [--binutils-mcs] [--binutils] [--gcc-stage1] [--newlib] [--gcc-stage2] [--clean-all] [--clean-binutils-mcs] [--clean-binutils] [--clean-gcc-stage1] [--clean-newlib] [--clean-gcc-stage2] [--help | -h]"
+	echo "Usage: build-toolchain [--all] [--binutils-mcs] [--binutils] [--gcc-stage1] [--newlib] [--gcc-stage2] [--clean-all] [--clean-binutils-mcs] [--clean-binutils] [--clean-gcc-stage1] [--clean-newlib] [--clean-gcc-stage2] [--clean-binutils-mcs-win] [--binutils-mcs-win] [--clean-binutils-win] [--binutils-win] [--clean-gcc-stage2-win] [--gcc-stage2-win] [--help | -h]"
 	exit 0
 fi
 
@@ -26,11 +27,11 @@ fi
 
 ### Binutils MCS
 
-if [[ $* == *--clean-binutils-mcs* ]]; then
+if [[ $* == "--clean-binutils-mcs" ]]; then
 	rm -fr $BUILD_FOLDER/binutils-mcs
 fi
 
-if [[ $* == *--binutils-mcs* || $* == *--all* ]]; then
+if [[ $* == "--binutils-mcs" || $* == *--all* ]]; then
 	export BINUTILS_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-binutils-gdb
 	mkdir -p $BUILD_FOLDER/binutils-mcs
 	mkdir -p $LOG_FOLDER
@@ -81,7 +82,7 @@ if [[ $* == *--clean-binutils* ]]; then
 	rm -fr $BUILD_FOLDER/binutils
 fi
 
-if [[ $* == *--binutils* || $* == *--all* ]]; then
+if [[ $* == "--binutils" || $* == *--all* ]]; then
 	export BINUTILS_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-binutils-gdb
 	mkdir -p $BUILD_FOLDER/binutils
 	mkdir -p $LOG_FOLDER
@@ -217,12 +218,12 @@ if [[ $* == *--newlib* || $* == *--all* ]]; then
 		echo "The build has failed during make of newlib"
 	fi
 	make install 2>&1 | tee -a $LOG_FOLDER/newlib.log
+	make install prefix=$INSTALL_FOLDER_WIN 2>&1 | tee -a $LOG_FOLDER/newlib-win.log
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during install of newlib"
 		exit 1
 	fi
 fi
-
 
 ### GCC stage2
 
@@ -230,7 +231,7 @@ if [[ $* == *--clean-gcc-stage2* ]]; then
 	rm -fr $BUILD_FOLDER/gcc-stage2
 fi
 
-if [[ $* == *--gcc-stage2* || $* == *--all* ]]; then
+if [[ $* == "--gcc-stage2" || $* == *--all* ]]; then
 	export GCC_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-gcc
 	mkdir -p $BUILD_FOLDER/gcc-stage2
 	mkdir -p $LOG_FOLDER
@@ -274,6 +275,161 @@ if [[ $* == *--gcc-stage2* || $* == *--all* ]]; then
 	make install 2>&1 | tee -a $LOG_FOLDER/gcc_stage2.log
 	if test ${PIPESTATUS[0]} -ne 0; then
 		echo "The build has failed during install of gcc (stage 2)"
+		exit 1
+	fi
+fi
+
+if [[ $* == *--clean-binutils-mcs-win* ]]; then
+	rm -fr $BUILD_FOLDER/binutils-mcs-win
+fi
+
+if [[ $* == *--binutils-mcs-win* || $* == *--all* ]]; then
+	export BINUTILS_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-binutils-gdb
+	mkdir -p $BUILD_FOLDER/binutils-mcs-win
+	mkdir -p $LOG_FOLDER
+	cd $BUILD_FOLDER/binutils-mcs-win
+	if ! $BINUTILS_SRC_FOLDER/configure \
+	LDFLAGS='-static' \
+	--target=mcs-elf \
+	--host=x86_64-w64-mingw32 \
+	--program-prefix=mcs-elf- \
+	--disable-threads \
+	--enable-nls \
+	--disable-itcl \
+	--disable-tk \
+	--disable-tcl \
+	--disable-winsup \
+	--disable-gdbtk \
+	--disable-libgui \
+	--disable-rda \
+	--disable-sid \
+	--disable-sim \
+	--disable-gdb \
+	--disable-newlib \
+	--disable-libgloss \
+	--disable-test-suite \
+	--enable-checking=release \
+	--with-gnu-ld \
+	--with-gnu-as \
+	--prefix=$INSTALL_FOLDER_WIN \
+	--disable-werror; then
+		echo "The build has failed during configure of binutils-mcs for Windows"
+		exit 1
+	fi
+        make --output-sync -j${PARALLEL_JOBS} LDFLAGS="-static" 2>&1 | tee $LOG_FOLDER/binutils_mcs-win.log
+	if test ${PIPESTATUS[0]} -ne 0; then
+		echo "The build has failed during make of binutils-mcs for Windows"
+		exit 1
+	fi
+	make install 2>&1 | tee -a $LOG_FOLDER/binutils_mcs-win.log
+	if test ${PIPESTATUS[0]} -ne 0; then
+		echo "The build has failed during install of binutils-mcs for Windows"
+		exit 1
+	fi
+fi
+
+
+if [[ $* == *--clean-binutils-win* ]]; then
+	rm -fr $BUILD_FOLDER/binutils-win
+fi
+
+if [[ $* == *--binutils-win* || $* == *--all* ]]; then
+	export BINUTILS_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-binutils-gdb
+	mkdir -p $BUILD_FOLDER/binutils-win
+	mkdir -p $LOG_FOLDER
+	cd $BUILD_FOLDER/binutils-win
+	if ! $BINUTILS_SRC_FOLDER/configure \
+	LDFLAGS='-static' \
+	--target=tricore-elf \
+	--host=x86_64-w64-mingw32 \
+	--enable-targets=mcs-elf \
+	--program-prefix=tricore-elf- \
+	--disable-threads \
+	--enable-nls \
+	--disable-itcl \
+	--disable-tk \
+	--disable-tcl \
+	--disable-winsup \
+	--disable-gdbtk \
+	--disable-libgui \
+	--disable-rda \
+	--disable-sid \
+	--disable-sim \
+	--disable-gdb \
+	--disable-newlib \
+	--disable-libgloss \
+	--disable-test-suite \
+	--enable-checking=release \
+	--with-gnu-ld \
+	--with-gnu-as \
+	--prefix=$INSTALL_FOLDER_WIN \
+	--disable-werror; then
+		echo "The build has failed during configure of binutils fow Windows"
+		exit 1
+	fi
+	make --output-sync -j${PARALLEL_JOBS} LDFLAGS="-static" 2>&1 | tee $LOG_FOLDER/binutils-win.log
+	if test ${PIPESTATUS[0]} -ne 0; then
+		echo "The build has failed during make of binutils for Windows"
+		exit 1
+	fi
+	make install 2>&1 | tee -a  $LOG_FOLDER/binutils-win.log
+	if test ${PIPESTATUS[0]} -ne 0; then
+		echo "The build has failed during install of binutils for Windows"
+		exit 1
+	fi
+fi
+
+
+
+if [[ $* == *--clean-gcc-stage2-win* ]]; then
+	rm -fr $BUILD_FOLDER/gcc-stage2
+fi
+
+if [[ $* == "--gcc-stage2-win" || $* == *--all* ]]; then
+	export GCC_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-gcc
+	mkdir -p $BUILD_FOLDER/gcc-stage2-win
+	mkdir -p $LOG_FOLDER
+	cd $BUILD_FOLDER/gcc-stage2-win
+	if ! $GCC_SRC_FOLDER/configure \
+	LDFLAGS='-static' \
+	CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
+	CPPFLAGS_FOR_TARGET='-g -O2 -gdwarf-3 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
+	--target=tricore-elf \
+	--host=x86_64-w64-mingw32 \
+	--enable-lib32 \
+	--disable-lib64 \
+	--prefix=$INSTALL_FOLDER_WIN \
+	--enable-languages=c,c++ \
+	--enable-libstdcxx-debug-flags='-gdwarf-3 -g -O0 -D_GLIBCXX_ASSERTIONS' \
+	--enable-c99 \
+	--enable-long-long \
+	--enable-checking \
+	--enable-nls \
+	--enable-static \
+	--disable-threads \
+	--disable-shared \
+	--with-headers=yes \
+	--with-gnu-ld \
+	--with-gnu-as \
+	--with-newlib=yes \
+	--enable-mingw-wildcard \
+	--disable-libstdcxx-pch \
+	--enable-newlib-elix-level=3 \
+	--enable-newlib-io-long-long \
+	--disable-newlib-supplied-syscalls \
+	--disable-libssp \
+	--disable-test-suite; then
+		echo "The build has failed during configure of gcc (stage 2) for Windows"
+		exit 1
+	fi
+	make -j${PARALLEL_JOBS} all 2>&1 | tee $LOG_FOLDER/gcc_stage2-win.log
+	if test ${PIPESTATUS[0]} -ne 0; then
+		echo "The build has failed during make of gcc (stage 2) for Windows"
+		exit 1
+	fi
+	make install 2>&1 | tee -a $LOG_FOLDER/gcc_stage2-win.log
+	if test ${PIPESTATUS[0]} -ne 0; then
+		echo "The build has failed during install of gcc (stage 2) for Windows"
 		exit 1
 	fi
 fi

--- a/build-toolchain
+++ b/build-toolchain
@@ -136,13 +136,18 @@ fi
 
 if [[ $* == *--gcc-stage1* || $* == *--all* ]]; then
 	export GCC_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-gcc
+	#Download necessary dependencies if they don't exist
+	if [[ ! -d $GCC_SRC_FOLDER/gmp ]]; then
+		cd -- $GCC_SRC_FOLDER
+		./contrib/download_prerequisites
+	fi
 	mkdir -p $BUILD_FOLDER/gcc-stage1
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/gcc-stage1
 	if ! $GCC_SRC_FOLDER/configure \
 	LDFLAGS='-static' \
-	CFLAGS_FOR_TARGET='-O2 -gdwarf-3' \
-	CXXFLAGS_FOR_TARGET='-O2 -gdwarf-3' \
+	CFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
+	CXXFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
 	--target=tricore-elf \
 	--enable-lib32 \
 	--disable-lib64 \
@@ -203,8 +208,8 @@ if [[ $* == *--newlib* || $* == *--all* ]]; then
 	export RANLIB_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-ranlib
 	export STRIP_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-strip
 	export READELF_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-readelf
-	if ! CFLAGS_FOR_TARGET='-O2 -ffunction-sections -mfast-div -fno-common' \
-	CXXFLAGS_FOR_TARGET='-O2  -ffunction-sections -mfast-div -fno-common' \
+	if ! CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffunction-sections -mfast-div -fno-common' \
+	CXXFLAGS_FOR_TARGET='-g -gdwarf-3 -O2  -ffunction-sections -mfast-div -fno-common' \
 	$NEWLIB_SRC_FOLDER/configure \
 	--target=tricore-elf \
 	--host=i686-w64-mingw32 \
@@ -225,6 +230,7 @@ if [[ $* == *--newlib* || $* == *--all* ]]; then
 	fi
 fi
 
+
 ### GCC stage2
 
 if [[ $* == *--clean-gcc-stage2* ]]; then
@@ -238,8 +244,8 @@ if [[ $* == "--gcc-stage2" || $* == *--all* ]]; then
 	cd $BUILD_FOLDER/gcc-stage2
 	if ! $GCC_SRC_FOLDER/configure \
 	LDFLAGS='-static' \
-	CFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
-	CPPFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
+	CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
+	CPPFLAGS_FOR_TARGET='-g -O2 -gdwarf-3 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	--target=tricore-elf \
 	--enable-lib32 \
 	--disable-lib64 \

--- a/build-toolchain
+++ b/build-toolchain
@@ -303,7 +303,7 @@ if [[ "$task_string" == "build-gcc-stage2" || "$task_string" == "build-all" || "
     CFLAGS="$CFLAGS" \
     CXXFLAGS="$CXXFLAGS" \
     CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
-    CPPFLAGS_FOR_TARGET='-g -O2 -gdwarf-3 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
+    CPPFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
     --target=tricore-elf \
     --enable-lib32 \
     --disable-lib64 \
@@ -465,8 +465,8 @@ if [[ "$task_string" == "build-gcc-stage2-win" || "$task_string" == "build-all" 
     LDFLAGS="$LDFLAGS" \
     CFLAGS="$CFLAGS" \
     CXXFLAGS="$CXXFLAGS" \
-    CFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
-    CPPFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
+    CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
+    CPPFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
     --target=tricore-elf \
     --host=x86_64-w64-mingw32 \
     --enable-lib32 \

--- a/build-toolchain
+++ b/build-toolchain
@@ -18,7 +18,7 @@ LDFLAGS="${LDFLAGS:--static -s}"
 
 print_usage() {
     cat <<EOF
-build-toolchain [--help | -h] [-o step] [--clean-all]
+build-toolchain [-h] [-c | -b] [-o step] [--clean-all]
 
 options:
   -h, --help             Show this help message and exit
@@ -27,8 +27,16 @@ options:
   -b, --build            Perform build of the selected step (default=all)
   --clean-all            Delete all build and install folders
 
-Supported build steps are: [all, binutils-mcs, binutils-tc, gcc-stage1, newlib, gcc-stage2,
-binutils-mcs-win, binutils-tc-win, gcc-stage2-win]
+Supported build steps are:
+  all               Build both windows and linux toolchains
+  binutils-mcs      Build MCS version of binutils for linux
+  binutils-tc       Build Tricore version of binutils for linux
+  gcc-stage1        Build stage1 GCC compiler for linux
+  newlib            Build standard library
+  gcc-stage2        Build stage2 (final) GCC compiler for linux
+  binutils-mcs-win  Build MCS version of binutils for win32
+  binutils-tc-win   Build Tricore version of binutils for win32
+  gcc-stage2-win    Build stage2 (final) GCC compiler for win32
 EOF
     exit
 }

--- a/build-toolchain
+++ b/build-toolchain
@@ -138,8 +138,8 @@ if [[ $* == *--gcc-stage1* || $* == *--all* ]]; then
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/gcc-stage1
 	if ! $GCC_SRC_FOLDER/configure \
-	CFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
-	CXXFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
+	CFLAGS_FOR_TARGET='-O2 -gdwarf-3' \
+	CXXFLAGS_FOR_TARGET='-O2 -gdwarf-3' \
 	--target=tricore-elf \
 	--enable-lib32 \
 	--disable-lib64 \
@@ -200,8 +200,8 @@ if [[ $* == *--newlib* || $* == *--all* ]]; then
 	export RANLIB_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-ranlib
 	export STRIP_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-strip
 	export READELF_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-readelf
-	if ! CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffunction-sections -mfast-div -fno-common' \
-	CXXFLAGS_FOR_TARGET='-g -gdwarf-3 -O2  -ffunction-sections -mfast-div -fno-common' \
+	if ! CFLAGS_FOR_TARGET='-O2 -ffunction-sections -mfast-div -fno-common' \
+	CXXFLAGS_FOR_TARGET='-O2  -ffunction-sections -mfast-div -fno-common' \
 	$NEWLIB_SRC_FOLDER/configure \
 	--target=tricore-elf \
 	--host=i686-w64-mingw32 \
@@ -234,8 +234,8 @@ if [[ $* == "--gcc-stage2" || $* == *--all* ]]; then
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/gcc-stage2
 	if ! $GCC_SRC_FOLDER/configure \
-	CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
-	CPPFLAGS_FOR_TARGET='-g -O2 -gdwarf-3 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
+	CFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
+	CPPFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	--target=tricore-elf \
 	--enable-lib32 \
 	--disable-lib64 \
@@ -385,8 +385,8 @@ if [[ $* == "--gcc-stage2-win" || $* == *--all* ]]; then
 	mkdir -p $LOG_FOLDER
 	cd $BUILD_FOLDER/gcc-stage2-win
 	if ! $GCC_SRC_FOLDER/configure \
-	CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
-	CPPFLAGS_FOR_TARGET='-g -O2 -gdwarf-3 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
+	CFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
+	CPPFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	--target=tricore-elf \
 	--host=x86_64-w64-mingw32 \
 	--enable-lib32 \

--- a/build-toolchain
+++ b/build-toolchain
@@ -17,7 +17,7 @@ CXXFLAGS="${CXXFLAGS:--O2}"
 LDFLAGS="${LDFLAGS:--static -s}"
 
 print_usage() {
-	cat <<EOF
+    cat <<EOF
 build-toolchain [--help | -h] [-o step] [--clean-all]
 
 options:
@@ -30,33 +30,33 @@ options:
 Supported build steps are: [all, binutils-mcs, binutils-tc, gcc-stage1, newlib, gcc-stage2,
 binutils-mcs-win, binutils-tc-win, gcc-stage2-win]
 EOF
-	exit
+    exit
 }
 
 clean_all_artifacts() {
-	rm -fr "$INSTALL_FOLDER" "$INSTALL_FOLDER_WIN" "$BUILD_FOLDER" "$LOG_FOLDER"
-	exit
+    rm -fr "$INSTALL_FOLDER" "$INSTALL_FOLDER_WIN" "$BUILD_FOLDER" "$LOG_FOLDER"
+    exit
 }
 
 parse_params() {
-	build_step="all"
-	build_task="build"
+    build_step="all"
+    build_task="build"
 
-	while :; do
-    	case "${1-}" in
-    	-h | --help) print_usage ;;
-		--clean-all) clean_all_artifacts ;;
-		-c | --clean) build_task="clean" ;;
-		-b | --build) build_task="build" ;;
-		-o | --only)
-		build_step="${2-}"
-		shift
-		;;
-    	-?*) echo "Unknown option: $1" ;;
-    *) break ;;
-    esac
-    shift
-  	done
+    while :; do
+        case "${1-}" in
+        -h | --help) print_usage ;;
+        --clean-all) clean_all_artifacts ;;
+        -c | --clean) build_task="clean" ;;
+        -b | --build) build_task="build" ;;
+        -o | --only)
+        build_step="${2-}"
+        shift
+        ;;
+        -?*) echo "Unknown option: $1" ;;
+        *) break ;;
+        esac
+        shift
+    done
 }
 
 parse_params "$@"
@@ -65,435 +65,435 @@ task_string="$build_task-$build_step"
 ### Binutils MCS
 
 if [[ "$task_string" == "clean-binutils-mcs" || "$task_string" == "clean-all" ]]; then
-	echo "Deleting $BUILD_FOLDER/binutils-mcs..."
-	rm -fr "$BUILD_FOLDER/binutils-mcs"
+    echo "Deleting $BUILD_FOLDER/binutils-mcs..."
+    rm -fr "$BUILD_FOLDER/binutils-mcs"
 fi
 
 if [[ "$task_string" == "build-binutils-mcs" || "$task_string" == "build-all" ]]; then
-	BINUTILS_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-binutils-gdb
-	mkdir -p "$BUILD_FOLDER/binutils-mcs"
-	mkdir -p "$LOG_FOLDER"
-	cd "$BUILD_FOLDER/binutils-mcs"
-	if ! $BINUTILS_SRC_FOLDER/configure \
-	LDFLAGS="$LDFLAGS" \
-	CFLAGS="$CFLAGS" \
-	CXXFLAGS="$CXXFLAGS" \
-	--target=mcs-elf \
-	--program-prefix=mcs-elf- \
-	--disable-threads \
-	--enable-nls \
-	--disable-itcl \
-	--disable-tk \
-	--disable-tcl \
-	--disable-winsup \
-	--disable-gdbtk \
-	--disable-libgui \
-	--disable-rda \
-	--disable-sid \
-	--disable-sim \
-	--disable-gdb \
-	--disable-newlib \
-	--disable-libgloss \
-	--disable-test-suite \
-	--enable-checking=release \
-	--with-gnu-ld \
-	--with-gnu-as \
-	--prefix="$INSTALL_FOLDER" \
-	--disable-werror; then
-		echo "The build has failed during configure of binutils-mcs"
-		exit 1
-	fi
+    BINUTILS_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-binutils-gdb
+    mkdir -p "$BUILD_FOLDER/binutils-mcs"
+    mkdir -p "$LOG_FOLDER"
+    cd "$BUILD_FOLDER/binutils-mcs"
+    if ! $BINUTILS_SRC_FOLDER/configure \
+    LDFLAGS="$LDFLAGS" \
+    CFLAGS="$CFLAGS" \
+    CXXFLAGS="$CXXFLAGS" \
+    --target=mcs-elf \
+    --program-prefix=mcs-elf- \
+    --disable-threads \
+    --enable-nls \
+    --disable-itcl \
+    --disable-tk \
+    --disable-tcl \
+    --disable-winsup \
+    --disable-gdbtk \
+    --disable-libgui \
+    --disable-rda \
+    --disable-sid \
+    --disable-sim \
+    --disable-gdb \
+    --disable-newlib \
+    --disable-libgloss \
+    --disable-test-suite \
+    --enable-checking=release \
+    --with-gnu-ld \
+    --with-gnu-as \
+    --prefix="$INSTALL_FOLDER" \
+    --disable-werror; then
+        echo "The build has failed during configure of binutils-mcs"
+        exit 1
+    fi
         make --output-sync -j${PARALLEL_JOBS} LDFLAGS="$LDFLAGS" 2>&1 | tee "$LOG_FOLDER/binutils_mcs.log"
-	if test ${PIPESTATUS[0]} -ne 0; then
-		echo "The build has failed during make of binutils-mcs"
-		exit 1
-	fi
-	make install 2>&1 | tee -a "$LOG_FOLDER/binutils_mcs.log"
-	if test ${PIPESTATUS[0]} -ne 0; then
-		echo "The build has failed during install of binutils-mcs"
-		exit 1
-	fi
+    if test ${PIPESTATUS[0]} -ne 0; then
+        echo "The build has failed during make of binutils-mcs"
+        exit 1
+    fi
+    make install 2>&1 | tee -a "$LOG_FOLDER/binutils_mcs.log"
+    if test ${PIPESTATUS[0]} -ne 0; then
+        echo "The build has failed during install of binutils-mcs"
+        exit 1
+    fi
 fi
 
 
 ### Binutils
 
 if [[ "$task_string" == "clean-binutils-tc" || "$task_string" == "clean-all" ]]; then
-	echo "Deleting $BUILD_FOLDER/binutils-tc..."
-	rm -fr "$BUILD_FOLDER/binutils-tc"
+    echo "Deleting $BUILD_FOLDER/binutils-tc..."
+    rm -fr "$BUILD_FOLDER/binutils-tc"
 fi
 
 if [[ "$task_string" == "build-binutils-tc" || "$task_string" == "build-all" ]]; then
-	BINUTILS_SRC_FOLDER="$TOOLCHAIN_ROOT/tricore-binutils-gdb"
-	mkdir -p "$BUILD_FOLDER/binutils-tc"
-	mkdir -p "$LOG_FOLDER"
-	cd "$BUILD_FOLDER/binutils-tc"
-	if ! $BINUTILS_SRC_FOLDER/configure \
-	LDFLAGS="$LDFLAGS" \
-	CFLAGS="$CFLAGS" \
-	CXXFLAGS="$CXXFLAGS" \
-	--target=tricore-elf \
-	--enable-targets=mcs-elf \
-	--program-prefix=tricore-elf- \
-	--disable-threads \
-	--enable-nls \
-	--disable-itcl \
-	--disable-tk \
-	--disable-tcl \
-	--disable-winsup \
-	--disable-gdbtk \
-	--disable-libgui \
-	--disable-rda \
-	--disable-sid \
-	--disable-sim \
-	--disable-gdb \
-	--disable-newlib \
-	--disable-libgloss \
-	--disable-test-suite \
-	--enable-checking=release \
-	--with-gnu-ld \
-	--with-gnu-as \
-	--prefix="$INSTALL_FOLDER" \
-	--disable-werror; then
-		echo "The build has failed during configure of binutils"
-		exit 1
-	fi
-	make --output-sync -j${PARALLEL_JOBS} LDFLAGS="$LDFLAGS" 2>&1 | tee "$LOG_FOLDER/binutils.log"
-	if test ${PIPESTATUS[0]} -ne 0; then
-		echo "The build has failed during make of binutils"
-		exit 1
-	fi
-	make install 2>&1 | tee -a  "$LOG_FOLDER/binutils.log"
-	if test ${PIPESTATUS[0]} -ne 0; then
-		echo "The build has failed during install of binutils"
-		exit 1
-	fi
+    BINUTILS_SRC_FOLDER="$TOOLCHAIN_ROOT/tricore-binutils-gdb"
+    mkdir -p "$BUILD_FOLDER/binutils-tc"
+    mkdir -p "$LOG_FOLDER"
+    cd "$BUILD_FOLDER/binutils-tc"
+    if ! $BINUTILS_SRC_FOLDER/configure \
+    LDFLAGS="$LDFLAGS" \
+    CFLAGS="$CFLAGS" \
+    CXXFLAGS="$CXXFLAGS" \
+    --target=tricore-elf \
+    --enable-targets=mcs-elf \
+    --program-prefix=tricore-elf- \
+    --disable-threads \
+    --enable-nls \
+    --disable-itcl \
+    --disable-tk \
+    --disable-tcl \
+    --disable-winsup \
+    --disable-gdbtk \
+    --disable-libgui \
+    --disable-rda \
+    --disable-sid \
+    --disable-sim \
+    --disable-gdb \
+    --disable-newlib \
+    --disable-libgloss \
+    --disable-test-suite \
+    --enable-checking=release \
+    --with-gnu-ld \
+    --with-gnu-as \
+    --prefix="$INSTALL_FOLDER" \
+    --disable-werror; then
+        echo "The build has failed during configure of binutils"
+        exit 1
+    fi
+    make --output-sync -j${PARALLEL_JOBS} LDFLAGS="$LDFLAGS" 2>&1 | tee "$LOG_FOLDER/binutils.log"
+    if test ${PIPESTATUS[0]} -ne 0; then
+        echo "The build has failed during make of binutils"
+        exit 1
+    fi
+    make install 2>&1 | tee -a  "$LOG_FOLDER/binutils.log"
+    if test ${PIPESTATUS[0]} -ne 0; then
+        echo "The build has failed during install of binutils"
+        exit 1
+    fi
 fi
 
 
 ### GCC stage1
 
 if [[ "$task_string" == "clean-gcc-stage1" || "$task_string" == "clean-all" ]]; then
-	echo "Deleting $BUILD_FOLDER/gcc-stage1..."
-	rm -fr "$BUILD_FOLDER/gcc-stage1"
+    echo "Deleting $BUILD_FOLDER/gcc-stage1..."
+    rm -fr "$BUILD_FOLDER/gcc-stage1"
 fi
 
 if [[ "$task_string" == "build-gcc-stage1" || "$task_string" == "build-all" ]]; then
-	GCC_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-gcc
-	# Download necessary dependencies if they don't exist
-	if [[ ! -d $GCC_SRC_FOLDER/gmp ]]; then
-		cd -- "$GCC_SRC_FOLDER"
-		./contrib/download_prerequisites
-	fi
-	mkdir -p "$BUILD_FOLDER/gcc-stage1"
-	mkdir -p "$LOG_FOLDER"
-	cd "$BUILD_FOLDER/gcc-stage1"
-	if ! $GCC_SRC_FOLDER/configure \
-	LDFLAGS="$LDFLAGS" \
-	CFLAGS="$CFLAGS" \
-	CXXFLAGS="$CXXFLAGS" \
-	CFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
-	CXXFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
-	--target=tricore-elf \
-	--enable-lib32 \
-	--disable-lib64 \
-	--prefix="$INSTALL_FOLDER" \
-	--enable-languages=c,c++ \
-	--enable-libstdcxx-debug-flags='-gdwarf-3 -g -O0 -D_GLIBCXX_ASSERTIONS' \
-	--enable-c99 \
-	--enable-long-long \
-	--enable-checking \
-	--enable-nls \
-	--enable-static \
-	--disable-threads \
-	--disable-shared \
-	--with-headers=yes \
-	--with-newlib=yes \
-	--enable-mingw-wildcard \
-	--disable-libstdcxx-pch \
-	--enable-newlib-elix-level=3 \
-	--enable-newlib-io-long-long \
-	--disable-newlib-supplied-syscalls \
-	--disable-libssp \
-	--disable-test-suite; then
-		echo "The build has failed during configure of gcc (stage 1)"
-		exit 1
-	fi
-	make -j${PARALLEL_JOBS} all-gcc 2>&1 | tee "$LOG_FOLDER/gcc_stage1.log"
-	if test ${PIPESTATUS[0]} -ne 0; then
-		echo "The build has failed during make of gcc (stage 1)"
-		exit 1
-	fi
-	make install-gcc 2>&1 | tee -a "$LOG_FOLDER/gcc_stage1.log"
-	if test ${PIPESTATUS[0]} -ne 0; then
-		echo "The build has failed during install of gcc (stage 1)"
-		exit 1
-	fi
+    GCC_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-gcc
+    # Download necessary dependencies if they don't exist
+    if [[ ! -d $GCC_SRC_FOLDER/gmp ]]; then
+        cd -- "$GCC_SRC_FOLDER"
+        ./contrib/download_prerequisites
+    fi
+    mkdir -p "$BUILD_FOLDER/gcc-stage1"
+    mkdir -p "$LOG_FOLDER"
+    cd "$BUILD_FOLDER/gcc-stage1"
+    if ! $GCC_SRC_FOLDER/configure \
+    LDFLAGS="$LDFLAGS" \
+    CFLAGS="$CFLAGS" \
+    CXXFLAGS="$CXXFLAGS" \
+    CFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
+    CXXFLAGS_FOR_TARGET='-g -O2 -gdwarf-3' \
+    --target=tricore-elf \
+    --enable-lib32 \
+    --disable-lib64 \
+    --prefix="$INSTALL_FOLDER" \
+    --enable-languages=c,c++ \
+    --enable-libstdcxx-debug-flags='-gdwarf-3 -g -O0 -D_GLIBCXX_ASSERTIONS' \
+    --enable-c99 \
+    --enable-long-long \
+    --enable-checking \
+    --enable-nls \
+    --enable-static \
+    --disable-threads \
+    --disable-shared \
+    --with-headers=yes \
+    --with-newlib=yes \
+    --enable-mingw-wildcard \
+    --disable-libstdcxx-pch \
+    --enable-newlib-elix-level=3 \
+    --enable-newlib-io-long-long \
+    --disable-newlib-supplied-syscalls \
+    --disable-libssp \
+    --disable-test-suite; then
+        echo "The build has failed during configure of gcc (stage 1)"
+        exit 1
+    fi
+    make -j${PARALLEL_JOBS} all-gcc 2>&1 | tee "$LOG_FOLDER/gcc_stage1.log"
+    if test ${PIPESTATUS[0]} -ne 0; then
+        echo "The build has failed during make of gcc (stage 1)"
+        exit 1
+    fi
+    make install-gcc 2>&1 | tee -a "$LOG_FOLDER/gcc_stage1.log"
+    if test ${PIPESTATUS[0]} -ne 0; then
+        echo "The build has failed during install of gcc (stage 1)"
+        exit 1
+    fi
 fi
 
 
 ### Newlib
 
 if [[ "$task_string" == "clean-newlib" || "$task_string" == "clean-all" ]]; then
-	echo "Deleting $BUILD_FOLDER/newlib..."
-	rm -fr "$BUILD_FOLDER/newlib"
+    echo "Deleting $BUILD_FOLDER/newlib..."
+    rm -fr "$BUILD_FOLDER/newlib"
 fi
 
 if [[ "$task_string" == "build-newlib" || "$task_string" == "build-all" ]]; then
-	NEWLIB_SRC_FOLDER="$TOOLCHAIN_ROOT/tricore-newlib-cygwin"
-	mkdir -p "$BUILD_FOLDER/newlib"
-	mkdir -p "$LOG_FOLDER"
-	cd "$BUILD_FOLDER/newlib"
-	export CC_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-gcc
-	export CXX_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-c++
-	export GCC_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-gcc
-	export AR_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-ar
-	export AS_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-as
-	export LD_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-ld
-	export NM_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-nm
-	export OBJDUMP_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-objdump
-	export RANLIB_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-ranlib
-	export STRIP_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-strip
-	export READELF_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-readelf
-	if ! CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffunction-sections -mfast-div -fno-common' \
-	CXXFLAGS_FOR_TARGET='-g -gdwarf-3 -O2  -ffunction-sections -mfast-div -fno-common' \
-	$NEWLIB_SRC_FOLDER/configure \
-	--target=tricore-elf \
-	--host=i686-w64-mingw32 \
-	--build=i686-pc-mingw32 \
-	--prefix="$INSTALL_FOLDER"; then
-		echo "The build has failed during configure of newlib"
-		exit 1
-	fi
-	make -j${PARALLEL_JOBS} LDFLAGS="$LDFLAGS" all 2>&1 | tee "$LOG_FOLDER/newlib.log"
-	if test ${PIPESTATUS[0]} -ne 0; then
-		echo "The build has failed during make of newlib"
-	fi
-	make install 2>&1 | tee -a "$LOG_FOLDER/newlib.log"
-	make install prefix=$INSTALL_FOLDER_WIN 2>&1 | tee -a "$LOG_FOLDER/newlib-win.log"
-	if test ${PIPESTATUS[0]} -ne 0; then
-		echo "The build has failed during install of newlib"
-		exit 1
-	fi
+    NEWLIB_SRC_FOLDER="$TOOLCHAIN_ROOT/tricore-newlib-cygwin"
+    mkdir -p "$BUILD_FOLDER/newlib"
+    mkdir -p "$LOG_FOLDER"
+    cd "$BUILD_FOLDER/newlib"
+    export CC_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-gcc
+    export CXX_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-c++
+    export GCC_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-gcc
+    export AR_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-ar
+    export AS_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-as
+    export LD_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-ld
+    export NM_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-nm
+    export OBJDUMP_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-objdump
+    export RANLIB_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-ranlib
+    export STRIP_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-strip
+    export READELF_FOR_TARGET=$INSTALL_FOLDER/bin/tricore-elf-readelf
+    if ! CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffunction-sections -mfast-div -fno-common' \
+    CXXFLAGS_FOR_TARGET='-g -gdwarf-3 -O2  -ffunction-sections -mfast-div -fno-common' \
+    $NEWLIB_SRC_FOLDER/configure \
+    --target=tricore-elf \
+    --host=i686-w64-mingw32 \
+    --build=i686-pc-mingw32 \
+    --prefix="$INSTALL_FOLDER"; then
+        echo "The build has failed during configure of newlib"
+        exit 1
+    fi
+    make -j${PARALLEL_JOBS} LDFLAGS="$LDFLAGS" all 2>&1 | tee "$LOG_FOLDER/newlib.log"
+    if test ${PIPESTATUS[0]} -ne 0; then
+        echo "The build has failed during make of newlib"
+    fi
+    make install 2>&1 | tee -a "$LOG_FOLDER/newlib.log"
+    make install prefix=$INSTALL_FOLDER_WIN 2>&1 | tee -a "$LOG_FOLDER/newlib-win.log"
+    if test ${PIPESTATUS[0]} -ne 0; then
+        echo "The build has failed during install of newlib"
+        exit 1
+    fi
 fi
 
 ### GCC stage2
 
 if [[ "$task_string" == "clean-gcc-stage2" || "$task_string" == "clean-all" ]]; then
-	echo "Deleting $BUILD_FOLDER/gcc-stage2..."
-	rm -fr "$BUILD_FOLDER/gcc-stage2"
+    echo "Deleting $BUILD_FOLDER/gcc-stage2..."
+    rm -fr "$BUILD_FOLDER/gcc-stage2"
 fi
 
 if [[ "$task_string" == "build-gcc-stage2" || "$task_string" == "build-all" ]]; then
-	export GCC_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-gcc
-	mkdir -p "$BUILD_FOLDER/gcc-stage2"
-	mkdir -p "$LOG_FOLDER"
-	cd "$BUILD_FOLDER/gcc-stage2"
-	if ! $GCC_SRC_FOLDER/configure \
-	LDFLAGS="$LDFLAGS" \
-	CFLAGS="$CFLAGS" \
-	CXXFLAGS="$CXXFLAGS" \
-	CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
-	CPPFLAGS_FOR_TARGET='-g -O2 -gdwarf-3 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
-	--target=tricore-elf \
-	--enable-lib32 \
-	--disable-lib64 \
-	--prefix="$INSTALL_FOLDER" \
-	--enable-languages=c,c++ \
-	--enable-libstdcxx-debug-flags='-gdwarf-3 -g -O0 -D_GLIBCXX_ASSERTIONS' \
-	--enable-c99 \
-	--enable-long-long \
-	--enable-checking \
-	--enable-nls \
-	--enable-static \
-	--disable-threads \
-	--disable-shared \
-	--with-headers=yes \
-	--with-gnu-ld \
-	--with-gnu-as \
-	--with-newlib=yes \
-	--enable-mingw-wildcard \
-	--disable-libstdcxx-pch \
-	--enable-newlib-elix-level=3 \
-	--enable-newlib-io-long-long \
-	--disable-newlib-supplied-syscalls \
-	--disable-libssp \
-	--disable-test-suite; then
-		echo "The build has failed during configure of gcc (stage 2)"
-		exit 1
-	fi
-	make -j${PARALLEL_JOBS} all 2>&1 | tee "$LOG_FOLDER/gcc_stage2.log"
-	if test ${PIPESTATUS[0]} -ne 0; then
-		echo "The build has failed during make of gcc (stage 2)"
-		exit 1
-	fi
-	make install-strip 2>&1 | tee -a "$LOG_FOLDER/gcc_stage2.log"
-	if test ${PIPESTATUS[0]} -ne 0; then
-		echo "The build has failed during install of gcc (stage 2)"
-		exit 1
-	fi
+    export GCC_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-gcc
+    mkdir -p "$BUILD_FOLDER/gcc-stage2"
+    mkdir -p "$LOG_FOLDER"
+    cd "$BUILD_FOLDER/gcc-stage2"
+    if ! $GCC_SRC_FOLDER/configure \
+    LDFLAGS="$LDFLAGS" \
+    CFLAGS="$CFLAGS" \
+    CXXFLAGS="$CXXFLAGS" \
+    CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
+    CPPFLAGS_FOR_TARGET='-g -O2 -gdwarf-3 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
+    --target=tricore-elf \
+    --enable-lib32 \
+    --disable-lib64 \
+    --prefix="$INSTALL_FOLDER" \
+    --enable-languages=c,c++ \
+    --enable-libstdcxx-debug-flags='-gdwarf-3 -g -O0 -D_GLIBCXX_ASSERTIONS' \
+    --enable-c99 \
+    --enable-long-long \
+    --enable-checking \
+    --enable-nls \
+    --enable-static \
+    --disable-threads \
+    --disable-shared \
+    --with-headers=yes \
+    --with-gnu-ld \
+    --with-gnu-as \
+    --with-newlib=yes \
+    --enable-mingw-wildcard \
+    --disable-libstdcxx-pch \
+    --enable-newlib-elix-level=3 \
+    --enable-newlib-io-long-long \
+    --disable-newlib-supplied-syscalls \
+    --disable-libssp \
+    --disable-test-suite; then
+        echo "The build has failed during configure of gcc (stage 2)"
+        exit 1
+    fi
+    make -j${PARALLEL_JOBS} all 2>&1 | tee "$LOG_FOLDER/gcc_stage2.log"
+    if test ${PIPESTATUS[0]} -ne 0; then
+        echo "The build has failed during make of gcc (stage 2)"
+        exit 1
+    fi
+    make install-strip 2>&1 | tee -a "$LOG_FOLDER/gcc_stage2.log"
+    if test ${PIPESTATUS[0]} -ne 0; then
+        echo "The build has failed during install of gcc (stage 2)"
+        exit 1
+    fi
 fi
 
 if [[ "$task_string" == "clean-binutils-mcs-win" || "$task_string" == "clean-all" ]]; then
-	echo "Deleting $BUILD_FOLDER/binutils-mcs-win..."
-	rm -fr "$BUILD_FOLDER/binutils-mcs-win"
+    echo "Deleting $BUILD_FOLDER/binutils-mcs-win..."
+    rm -fr "$BUILD_FOLDER/binutils-mcs-win"
 fi
 
 if [[ "$task_string" == "build-binutils-mcs-win" || "$task_string" == "build-all" ]]; then
-	export BINUTILS_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-binutils-gdb
-	mkdir -p "$BUILD_FOLDER/binutils-mcs-win"
-	mkdir -p "$LOG_FOLDER"
-	cd "$BUILD_FOLDER/binutils-mcs-win"
-	if ! $BINUTILS_SRC_FOLDER/configure \
-	LDFLAGS="$LDFLAGS" \
-	CFLAGS="$CFLAGS" \
-	CXXFLAGS="$CXXFLAGS" \
-	--target=mcs-elf \
-	--host=x86_64-w64-mingw32 \
-	--program-prefix=mcs-elf- \
-	--disable-threads \
-	--enable-nls \
-	--disable-itcl \
-	--disable-tk \
-	--disable-tcl \
-	--disable-winsup \
-	--disable-gdbtk \
-	--disable-libgui \
-	--disable-rda \
-	--disable-sid \
-	--disable-sim \
-	--disable-gdb \
-	--disable-newlib \
-	--disable-libgloss \
-	--disable-test-suite \
-	--enable-checking=release \
-	--with-gnu-ld \
-	--with-gnu-as \
-	--prefix="$INSTALL_FOLDER_WIN" \
-	--disable-werror; then
-		echo "The build has failed during configure of binutils-mcs for Windows"
-		exit 1
-	fi
+    export BINUTILS_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-binutils-gdb
+    mkdir -p "$BUILD_FOLDER/binutils-mcs-win"
+    mkdir -p "$LOG_FOLDER"
+    cd "$BUILD_FOLDER/binutils-mcs-win"
+    if ! $BINUTILS_SRC_FOLDER/configure \
+    LDFLAGS="$LDFLAGS" \
+    CFLAGS="$CFLAGS" \
+    CXXFLAGS="$CXXFLAGS" \
+    --target=mcs-elf \
+    --host=x86_64-w64-mingw32 \
+    --program-prefix=mcs-elf- \
+    --disable-threads \
+    --enable-nls \
+    --disable-itcl \
+    --disable-tk \
+    --disable-tcl \
+    --disable-winsup \
+    --disable-gdbtk \
+    --disable-libgui \
+    --disable-rda \
+    --disable-sid \
+    --disable-sim \
+    --disable-gdb \
+    --disable-newlib \
+    --disable-libgloss \
+    --disable-test-suite \
+    --enable-checking=release \
+    --with-gnu-ld \
+    --with-gnu-as \
+    --prefix="$INSTALL_FOLDER_WIN" \
+    --disable-werror; then
+        echo "The build has failed during configure of binutils-mcs for Windows"
+        exit 1
+    fi
         make --output-sync -j${PARALLEL_JOBS} 2>&1 | tee "$LOG_FOLDER/binutils_mcs-win.log"
-	if test ${PIPESTATUS[0]} -ne 0; then
-		echo "The build has failed during make of binutils-mcs for Windows"
-		exit 1
-	fi
-	make install 2>&1 | tee -a "$LOG_FOLDER/binutils_mcs-win.log"
-	if test ${PIPESTATUS[0]} -ne 0; then
-		echo "The build has failed during install of binutils-mcs for Windows"
-		exit 1
-	fi
+    if test ${PIPESTATUS[0]} -ne 0; then
+        echo "The build has failed during make of binutils-mcs for Windows"
+        exit 1
+    fi
+    make install 2>&1 | tee -a "$LOG_FOLDER/binutils_mcs-win.log"
+    if test ${PIPESTATUS[0]} -ne 0; then
+        echo "The build has failed during install of binutils-mcs for Windows"
+        exit 1
+    fi
 fi
 
 
 if [[ "$task_string" == "clean-binutils-tc-win" || "$task_string" == "clean-all" ]]; then
-	echo "Deleting $BUILD_FOLDER/binutils-tc-win..."
-	rm -fr "$BUILD_FOLDER/binutils-tc-win"
+    echo "Deleting $BUILD_FOLDER/binutils-tc-win..."
+    rm -fr "$BUILD_FOLDER/binutils-tc-win"
 fi
 
 if [[ "$task_string" == "build-binutils-tc-win" || "$task_string" == "build-all" ]]; then
-	BINUTILS_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-binutils-gdb
-	mkdir -p "$BUILD_FOLDER/binutils-tc-win"
-	mkdir -p "$LOG_FOLDER"
-	cd "$BUILD_FOLDER/binutils-tc-win"
-	if ! $BINUTILS_SRC_FOLDER/configure \
-	LDFLAGS="$LDFLAGS" \
-	CFLAGS="$CFLAGS" \
-	CXXFLAGS="$CXXFLAGS" \
-	--target=tricore-elf \
-	--host=x86_64-w64-mingw32 \
-	--enable-targets=mcs-elf \
-	--program-prefix=tricore-elf- \
-	--disable-threads \
-	--enable-nls \
-	--disable-itcl \
-	--disable-tk \
-	--disable-tcl \
-	--disable-winsup \
-	--disable-gdbtk \
-	--disable-libgui \
-	--disable-rda \
-	--disable-sid \
-	--disable-sim \
-	--disable-gdb \
-	--disable-newlib \
-	--disable-libgloss \
-	--disable-test-suite \
-	--enable-checking=release \
-	--with-gnu-ld \
-	--with-gnu-as \
-	--prefix="$INSTALL_FOLDER_WIN" \
-	--disable-werror; then
-		echo "The build has failed during configure of binutils fow Windows"
-		exit 1
-	fi
-	make --output-sync -j${PARALLEL_JOBS} 2>&1 | tee "$LOG_FOLDER/binutils-tc-win.log"
-	if test ${PIPESTATUS[0]} -ne 0; then
-		echo "The build has failed during make of binutils for Windows"
-		exit 1
-	fi
-	make install 2>&1 | tee -a  "$LOG_FOLDER/binutils-tc-win.log"
-	if test ${PIPESTATUS[0]} -ne 0; then
-		echo "The build has failed during install of binutils for Windows"
-		exit 1
-	fi
+    BINUTILS_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-binutils-gdb
+    mkdir -p "$BUILD_FOLDER/binutils-tc-win"
+    mkdir -p "$LOG_FOLDER"
+    cd "$BUILD_FOLDER/binutils-tc-win"
+    if ! $BINUTILS_SRC_FOLDER/configure \
+    LDFLAGS="$LDFLAGS" \
+    CFLAGS="$CFLAGS" \
+    CXXFLAGS="$CXXFLAGS" \
+    --target=tricore-elf \
+    --host=x86_64-w64-mingw32 \
+    --enable-targets=mcs-elf \
+    --program-prefix=tricore-elf- \
+    --disable-threads \
+    --enable-nls \
+    --disable-itcl \
+    --disable-tk \
+    --disable-tcl \
+    --disable-winsup \
+    --disable-gdbtk \
+    --disable-libgui \
+    --disable-rda \
+    --disable-sid \
+    --disable-sim \
+    --disable-gdb \
+    --disable-newlib \
+    --disable-libgloss \
+    --disable-test-suite \
+    --enable-checking=release \
+    --with-gnu-ld \
+    --with-gnu-as \
+    --prefix="$INSTALL_FOLDER_WIN" \
+    --disable-werror; then
+        echo "The build has failed during configure of binutils fow Windows"
+        exit 1
+    fi
+    make --output-sync -j${PARALLEL_JOBS} 2>&1 | tee "$LOG_FOLDER/binutils-tc-win.log"
+    if test ${PIPESTATUS[0]} -ne 0; then
+        echo "The build has failed during make of binutils for Windows"
+        exit 1
+    fi
+    make install 2>&1 | tee -a  "$LOG_FOLDER/binutils-tc-win.log"
+    if test ${PIPESTATUS[0]} -ne 0; then
+        echo "The build has failed during install of binutils for Windows"
+        exit 1
+    fi
 fi
 
 
 
 if [[ "$task_string" == "clean-gcc-stage2-win" || "$task_string" == "clean-all" ]]; then
-	echo "Deleting $BUILD_FOLDER/gcc-stage2-win..."
-	rm -fr "$BUILD_FOLDER/gcc-stage2-win"
+    echo "Deleting $BUILD_FOLDER/gcc-stage2-win..."
+    rm -fr "$BUILD_FOLDER/gcc-stage2-win"
 fi
 
 if [[ "$task_string" == "build-gcc-stage2-win" || "$task_string" == "build-all" ]]; then
-	GCC_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-gcc
-	mkdir -p "$BUILD_FOLDER/gcc-stage2-win"
-	mkdir -p "$LOG_FOLDER"
-	cd "$BUILD_FOLDER/gcc-stage2-win"
-	if ! $GCC_SRC_FOLDER/configure \
-	LDFLAGS="$LDFLAGS" \
-	CFLAGS="$CFLAGS" \
-	CXXFLAGS="$CXXFLAGS" \
-	CFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
-	CPPFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
-	--target=tricore-elf \
-	--host=x86_64-w64-mingw32 \
-	--enable-lib32 \
-	--disable-lib64 \
-	--prefix="$INSTALL_FOLDER_WIN" \
-	--enable-languages=c,c++ \
-	--enable-libstdcxx-debug-flags='-gdwarf-3 -g -O0 -D_GLIBCXX_ASSERTIONS' \
-	--enable-c99 \
-	--enable-long-long \
-	--enable-checking \
-	--enable-nls \
-	--enable-static \
-	--disable-threads \
-	--disable-shared \
-	--with-headers=yes \
-	--with-gnu-ld \
-	--with-gnu-as \
-	--with-newlib=yes \
-	--enable-mingw-wildcard \
-	--disable-libstdcxx-pch \
-	--enable-newlib-elix-level=3 \
-	--enable-newlib-io-long-long \
-	--disable-newlib-supplied-syscalls \
-	--disable-libssp \
-	--disable-test-suite; then
-		echo "The build has failed during configure of gcc (stage 2) for Windows"
-		exit 1
-	fi
-	make -j${PARALLEL_JOBS} all 2>&1 | tee "$LOG_FOLDER/gcc_stage2-win.log"
-	if test ${PIPESTATUS[0]} -ne 0; then
-		echo "The build has failed during make of gcc (stage 2) for Windows"
-		exit 1
-	fi
-	make install-strip 2>&1 | tee -a "$LOG_FOLDER/gcc_stage2-win.log"
-	if test ${PIPESTATUS[0]} -ne 0; then
-		echo "The build has failed during install of gcc (stage 2) for Windows"
-		exit 1
-	fi
+    GCC_SRC_FOLDER=$TOOLCHAIN_ROOT/tricore-gcc
+    mkdir -p "$BUILD_FOLDER/gcc-stage2-win"
+    mkdir -p "$LOG_FOLDER"
+    cd "$BUILD_FOLDER/gcc-stage2-win"
+    if ! $GCC_SRC_FOLDER/configure \
+    LDFLAGS="$LDFLAGS" \
+    CFLAGS="$CFLAGS" \
+    CXXFLAGS="$CXXFLAGS" \
+    CFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
+    CPPFLAGS_FOR_TARGET='-O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
+    --target=tricore-elf \
+    --host=x86_64-w64-mingw32 \
+    --enable-lib32 \
+    --disable-lib64 \
+    --prefix="$INSTALL_FOLDER_WIN" \
+    --enable-languages=c,c++ \
+    --enable-libstdcxx-debug-flags='-gdwarf-3 -g -O0 -D_GLIBCXX_ASSERTIONS' \
+    --enable-c99 \
+    --enable-long-long \
+    --enable-checking \
+    --enable-nls \
+    --enable-static \
+    --disable-threads \
+    --disable-shared \
+    --with-headers=yes \
+    --with-gnu-ld \
+    --with-gnu-as \
+    --with-newlib=yes \
+    --enable-mingw-wildcard \
+    --disable-libstdcxx-pch \
+    --enable-newlib-elix-level=3 \
+    --enable-newlib-io-long-long \
+    --disable-newlib-supplied-syscalls \
+    --disable-libssp \
+    --disable-test-suite; then
+        echo "The build has failed during configure of gcc (stage 2) for Windows"
+        exit 1
+    fi
+    make -j${PARALLEL_JOBS} all 2>&1 | tee "$LOG_FOLDER/gcc_stage2-win.log"
+    if test ${PIPESTATUS[0]} -ne 0; then
+        echo "The build has failed during make of gcc (stage 2) for Windows"
+        exit 1
+    fi
+    make install-strip 2>&1 | tee -a "$LOG_FOLDER/gcc_stage2-win.log"
+    if test ${PIPESTATUS[0]} -ne 0; then
+        echo "The build has failed during install of gcc (stage 2) for Windows"
+        exit 1
+    fi
 fi

--- a/install-deps
+++ b/install-deps
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+if [ ! -f /etc/lsb_release ] && [ ! -f /etc/debian_version ]
+then
+    echo "Script is meant to install packages on Debian/Ubuntu based distributions"
+    echo "Pleas install dependencies manually on other distributions"
+    exit 1
+fi
+
+apt-get update
+apt-get -y install build-essential build-essential gcc-mingw-w64 g++-mingw-w64 texinfo flex bison libmpfr-dev libgmp-dev libmpc-dev zip


### PR DESCRIPTION
PR introduces following changes:

- Merge linux-crosscompile branch to allow cross-compilation of Windows toolchain from linux
- Make build script use parametric `CFLAGS`, `CXXFLAGS` and `LDFLAGS`. If not set from environment,
  script will use default values
- Refactor build script to have a cleaner command line interface
- Various shellcheck fixes and properly format file using only spaces
- `all` now compiles both windows and linux toolchains. Added a new linux build steps to build only `linux` toolchain