### PR TITLE
Use correct C++ flag override variable in build script

### DIFF
--- a/build-toolchain
+++ b/build-toolchain
@@ -238,7 +238,7 @@ if [[ $* == *--gcc-stage2* || $* == *--all* ]]; then
 	if ! $GCC_SRC_FOLDER/configure \
 	LDFLAGS='-static' \
 	CFLAGS_FOR_TARGET='-g -gdwarf-3 -O2 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
-	CPPFLAGS_FOR_TARGET='-g -O2 -gdwarf-3 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
+	CXXFLAGS_FOR_TARGET='-g -O2 -gdwarf-3 -ffast-math -ffunction-sections -mfast-div -fno-common -mno-eabi-bitfield-limit' \
 	--target=tricore-elf \
 	--enable-lib32 \
 	--disable-lib64 \


### PR DESCRIPTION
Stage 2 of the toolchain build is using wrong variable to override C++ compiler flags for the target artifacts, CPPFLAGS_FOR_TARGET which is targeted to the pre-processors.

This fix is necessary to be able to build toolchain with GCC 13.3 because in libstdc++v3, the new C++20 format implementation requires the flag `-mno-eabi-bitfield-limit` to overcome 32 bit limit for bit-fields imposed by the Tricore EABI, which is currently not applied due to wrong variable name.

